### PR TITLE
Expand canonical piece library

### DIFF
--- a/src/data/levels/foundations/01-crossroads.js
+++ b/src/data/levels/foundations/01-crossroads.js
@@ -9,7 +9,7 @@ const crossroads = {
     [1, 1, 0, 0, 1],
     [0, 1, 1, 1, 0],
   ],
-  pieceIds: [PIECE_IDS.T, PIECE_IDS.SQUARE, PIECE_IDS.LINE, PIECE_IDS.L],
+  pieceIds: [PIECE_IDS.T4, PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };
 
 export default crossroads;

--- a/src/data/levels/foundations/02-columns.js
+++ b/src/data/levels/foundations/02-columns.js
@@ -9,7 +9,7 @@ const columns = {
     [1, 1, 1, 1],
     [1, 1, 1, 0],
   ],
-  pieceIds: [PIECE_IDS.T, PIECE_IDS.SQUARE, PIECE_IDS.LINE, PIECE_IDS.L],
+  pieceIds: [PIECE_IDS.T4, PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };
 
 export default columns;

--- a/src/data/levels/foundations/03-stair-step.js
+++ b/src/data/levels/foundations/03-stair-step.js
@@ -9,7 +9,7 @@ const stairStep = {
     [1, 1, 1, 1],
     [1, 1, 1, 0],
   ],
-  pieceIds: [PIECE_IDS.T, PIECE_IDS.SQUARE, PIECE_IDS.LINE, PIECE_IDS.L],
+  pieceIds: [PIECE_IDS.T4, PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };
 
 export default stairStep;

--- a/src/data/levels/foundations/04-double-notch.js
+++ b/src/data/levels/foundations/04-double-notch.js
@@ -9,7 +9,7 @@ const doubleNotch = {
     [1, 0, 1, 1],
     [1, 0, 1, 1],
   ],
-  pieceIds: [PIECE_IDS.T, PIECE_IDS.SQUARE, PIECE_IDS.LINE, PIECE_IDS.L],
+  pieceIds: [PIECE_IDS.T4, PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };
 
 export default doubleNotch;

--- a/src/data/levels/foundations/05-crag.js
+++ b/src/data/levels/foundations/05-crag.js
@@ -9,7 +9,7 @@ const crag = {
     [1, 1, 0, 0, 0],
     [1, 1, 1, 0, 0],
   ],
-  pieceIds: [PIECE_IDS.T, PIECE_IDS.SQUARE, PIECE_IDS.LINE, PIECE_IDS.L],
+  pieceIds: [PIECE_IDS.T4, PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };
 
 export default crag;

--- a/src/data/levels/foundations/06-swoop.js
+++ b/src/data/levels/foundations/06-swoop.js
@@ -9,7 +9,7 @@ const swoop = {
     [0, 0, 1, 1, 0],
     [1, 1, 1, 0, 0],
   ],
-  pieceIds: [PIECE_IDS.T, PIECE_IDS.SQUARE, PIECE_IDS.LINE, PIECE_IDS.L],
+  pieceIds: [PIECE_IDS.T4, PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };
 
 export default swoop;

--- a/src/data/levels/foundations/07-bridge.js
+++ b/src/data/levels/foundations/07-bridge.js
@@ -9,7 +9,7 @@ const bridge = {
     [0, 0, 0, 1, 0],
     [1, 1, 1, 1, 1],
   ],
-  pieceIds: [PIECE_IDS.T, PIECE_IDS.SQUARE, PIECE_IDS.LINE, PIECE_IDS.L],
+  pieceIds: [PIECE_IDS.T4, PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };
 
 export default bridge;

--- a/src/data/levels/foundations/08-switchback.js
+++ b/src/data/levels/foundations/08-switchback.js
@@ -9,7 +9,7 @@ const switchback = {
     [0, 1, 1, 0, 0],
     [1, 1, 1, 0, 0],
   ],
-  pieceIds: [PIECE_IDS.T, PIECE_IDS.SQUARE, PIECE_IDS.LINE, PIECE_IDS.L],
+  pieceIds: [PIECE_IDS.T4, PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };
 
 export default switchback;

--- a/src/data/pieces/index.js
+++ b/src/data/pieces/index.js
@@ -1,49 +1,139 @@
 export const PIECE_IDS = {
-  T: 't-piece',
-  SQUARE: 'square-piece',
-  LINE: 'line-piece',
-  L: 'l-piece',
+  SQUARE2: 'square2',
+  LINE3: 'line3',
+  LINE4: 'line4',
+  L3: 'l3',
+  L4: 'l4',
+  T4: 't4',
+  Z4: 'z4',
+  S4: 's4',
+  P5: 'p5',
+  CROSS5: 'cross5',
+  LONG_L5: 'longL5',
+  U5: 'u5',
 };
 
 export const PIECE_LIBRARY = {
-  [PIECE_IDS.T]: {
-    id: PIECE_IDS.T,
-    name: 'T Piece',
-    color: '#5b8def',
-    shape: [
-      [1, 1, 1],
-      [0, 1, 0],
-    ],
-  },
-  [PIECE_IDS.SQUARE]: {
-    id: PIECE_IDS.SQUARE,
-    name: 'Square',
+  [PIECE_IDS.SQUARE2]: {
+    id: PIECE_IDS.SQUARE2,
+    name: 'Square (2x2)',
     color: '#64b56a',
     shape: [
       [1, 1],
       [1, 1],
     ],
   },
-  [PIECE_IDS.LINE]: {
-    id: PIECE_IDS.LINE,
-    name: 'Line',
+  [PIECE_IDS.LINE3]: {
+    id: PIECE_IDS.LINE3,
+    name: 'Line (3)',
     color: '#f0a452',
     shape: [[1, 1, 1]],
   },
-  [PIECE_IDS.L]: {
-    id: PIECE_IDS.L,
-    name: 'L Piece',
+  [PIECE_IDS.LINE4]: {
+    id: PIECE_IDS.LINE4,
+    name: 'Line (4)',
+    color: '#d79a2b',
+    shape: [[1, 1, 1, 1]],
+  },
+  [PIECE_IDS.L3]: {
+    id: PIECE_IDS.L3,
+    name: 'L (3)',
     color: '#dc6d4b',
     shape: [
       [1, 0],
       [1, 1],
     ],
   },
+  [PIECE_IDS.L4]: {
+    id: PIECE_IDS.L4,
+    name: 'L (4)',
+    color: '#c75a41',
+    shape: [
+      [1, 0],
+      [1, 0],
+      [1, 1],
+    ],
+  },
+  [PIECE_IDS.T4]: {
+    id: PIECE_IDS.T4,
+    name: 'T (4)',
+    color: '#5b8def',
+    shape: [
+      [1, 1, 1],
+      [0, 1, 0],
+    ],
+  },
+  [PIECE_IDS.Z4]: {
+    id: PIECE_IDS.Z4,
+    name: 'Z (4)',
+    color: '#b368c9',
+    shape: [
+      [1, 1, 0],
+      [0, 1, 1],
+    ],
+  },
+  [PIECE_IDS.S4]: {
+    id: PIECE_IDS.S4,
+    name: 'S (4)',
+    color: '#4db5a7',
+    shape: [
+      [0, 1, 1],
+      [1, 1, 0],
+    ],
+  },
+  [PIECE_IDS.P5]: {
+    id: PIECE_IDS.P5,
+    name: 'P (5)',
+    color: '#d66f9b',
+    shape: [
+      [1, 1],
+      [1, 1],
+      [1, 0],
+    ],
+  },
+  [PIECE_IDS.CROSS5]: {
+    id: PIECE_IDS.CROSS5,
+    name: 'Cross (5)',
+    color: '#7486d9',
+    shape: [
+      [0, 1, 0],
+      [1, 1, 1],
+      [0, 1, 0],
+    ],
+  },
+  [PIECE_IDS.LONG_L5]: {
+    id: PIECE_IDS.LONG_L5,
+    name: 'Long L (5)',
+    color: '#cc7a3b',
+    shape: [
+      [1, 0],
+      [1, 0],
+      [1, 0],
+      [1, 1],
+    ],
+  },
+  [PIECE_IDS.U5]: {
+    id: PIECE_IDS.U5,
+    name: 'U (5)',
+    color: '#6f97b5',
+    shape: [
+      [1, 0, 1],
+      [1, 1, 1],
+    ],
+  },
 };
 
 export const PIECES = [
-  PIECE_LIBRARY[PIECE_IDS.T],
-  PIECE_LIBRARY[PIECE_IDS.SQUARE],
-  PIECE_LIBRARY[PIECE_IDS.LINE],
-  PIECE_LIBRARY[PIECE_IDS.L],
+  PIECE_LIBRARY[PIECE_IDS.SQUARE2],
+  PIECE_LIBRARY[PIECE_IDS.LINE3],
+  PIECE_LIBRARY[PIECE_IDS.LINE4],
+  PIECE_LIBRARY[PIECE_IDS.L3],
+  PIECE_LIBRARY[PIECE_IDS.L4],
+  PIECE_LIBRARY[PIECE_IDS.T4],
+  PIECE_LIBRARY[PIECE_IDS.Z4],
+  PIECE_LIBRARY[PIECE_IDS.S4],
+  PIECE_LIBRARY[PIECE_IDS.P5],
+  PIECE_LIBRARY[PIECE_IDS.CROSS5],
+  PIECE_LIBRARY[PIECE_IDS.LONG_L5],
+  PIECE_LIBRARY[PIECE_IDS.U5],
 ];

--- a/src/utils/grid.test.js
+++ b/src/utils/grid.test.js
@@ -11,9 +11,9 @@ import {
   rotateShape,
 } from './grid';
 
-const T_PIECE = PIECE_LIBRARY[PIECE_IDS.T];
-const SQUARE_PIECE = PIECE_LIBRARY[PIECE_IDS.SQUARE];
-const LINE_PIECE = PIECE_LIBRARY[PIECE_IDS.LINE];
+const T_PIECE = PIECE_LIBRARY[PIECE_IDS.T4];
+const SQUARE_PIECE = PIECE_LIBRARY[PIECE_IDS.SQUARE2];
+const LINE_PIECE = PIECE_LIBRARY[PIECE_IDS.LINE3];
 
 describe('grid utilities', () => {
   describe('normalizeRotation', () => {
@@ -54,7 +54,7 @@ describe('grid utilities', () => {
         [1, 1, 1],
       ];
       const placedPieces = {
-        [PIECE_IDS.SQUARE]: { x: 0, y: 0, rotation: 0 },
+        [PIECE_IDS.SQUARE2]: { x: 0, y: 0, rotation: 0 },
       };
 
       expect(canPlacePiece(board, PIECES, placedPieces, T_PIECE, 0, 0)).toBe(false);
@@ -91,19 +91,19 @@ describe('grid utilities', () => {
 
   describe('placePiece and removePiece', () => {
     it('stores normalized rotation when placing a piece', () => {
-      expect(placePiece({}, PIECE_IDS.T, 1, 2, -1)).toEqual({
-        [PIECE_IDS.T]: { x: 1, y: 2, rotation: 3 },
+      expect(placePiece({}, PIECE_IDS.T4, 1, 2, -1)).toEqual({
+        [PIECE_IDS.T4]: { x: 1, y: 2, rotation: 3 },
       });
     });
 
     it('removes only the targeted piece', () => {
       const placedPieces = {
-        [PIECE_IDS.T]: { x: 0, y: 0, rotation: 0 },
-        [PIECE_IDS.SQUARE]: { x: 1, y: 1, rotation: 0 },
+        [PIECE_IDS.T4]: { x: 0, y: 0, rotation: 0 },
+        [PIECE_IDS.SQUARE2]: { x: 1, y: 1, rotation: 0 },
       };
 
-      expect(removePiece(placedPieces, PIECE_IDS.T)).toEqual({
-        [PIECE_IDS.SQUARE]: { x: 1, y: 1, rotation: 0 },
+      expect(removePiece(placedPieces, PIECE_IDS.T4)).toEqual({
+        [PIECE_IDS.SQUARE2]: { x: 1, y: 1, rotation: 0 },
       });
     });
   });
@@ -115,7 +115,7 @@ describe('grid utilities', () => {
         [1, 1, 1],
       ];
       const placedPieces = {
-        [PIECE_IDS.SQUARE]: { x: 0, y: 0, rotation: 0 },
+        [PIECE_IDS.SQUARE2]: { x: 0, y: 0, rotation: 0 },
       };
       const occupancyMap = buildOccupancyMap(board, PIECES, placedPieces);
 
@@ -128,7 +128,7 @@ describe('grid utilities', () => {
         [1, 1],
       ];
       const placedPieces = {
-        [PIECE_IDS.SQUARE]: { x: 0, y: 0, rotation: 0 },
+        [PIECE_IDS.SQUARE2]: { x: 0, y: 0, rotation: 0 },
       };
       const occupancyMap = buildOccupancyMap(board, PIECES, placedPieces);
 


### PR DESCRIPTION
## Summary
- expand the canonical piece library to the approved 12-piece set
- migrate the existing Foundations sample levels to the new stable piece IDs
- update the grid utility tests to use the new canonical IDs

## Testing
- npm test
- npm run validate:levels
- npm run build

Closes #7