### PR TITLE
Align fail-late language in CozyBlock design docs

### DIFF
--- a/docs/level-design-system.md
+++ b/docs/level-design-system.md
@@ -124,7 +124,7 @@ Key drivers of difficulty:
 ### Harder Levels
 
 - multiple plausible moves
-- delayed failure
+- visible downstream pressure
 - tighter constraints
 
 Avoid artificial difficulty, such as large boards with no structure.

--- a/docs/world-design-strategy.md
+++ b/docs/world-design-strategy.md
@@ -120,7 +120,7 @@ This structure is a guideline, not a strict requirement.
 | 9 | Space gets crowded | - | same | medium, compact | immediate | density, limited options |
 | 10 | Some pieces dominate | p5 | + p5 | medium | immediate | large pieces shape the board |
 | 11 | Build around a center | cross5 | + cross5 | medium, central layouts | immediate | anchor-based solving |
-| 12 | You must think ahead | - | same | medium -> large | mid-world escalation | sequencing, fail-late puzzles |
+| 12 | You must think ahead | - | same | medium -> large | mid-world escalation | sequencing, visible downstream pressure |
 | 13 | Length creates commitment | longL5 | + longL5 | large, corridors | immediate | long dependencies |
 | 14 | Space isn't always solid | u5 | + u5 | large, holes/pockets | immediate | negative space reasoning |
 | 15 | Break the rules (optional) | single1 | + single1 (limited) | varied | immediate | final-move logic, cleanup |


### PR DESCRIPTION
## Summary
- replace remaining fail-late wording in the world strategy doc
- replace delayed-failure wording in the level design system
- align both docs with the repo's preference for visible pressure over hidden punishment

Closes #17