### PR TITLE
Add set-aware world and level navigation

### DIFF
--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createLevelPieceInstances, LEVELS } from '../data/levels';
+import { getLevelNavigation, getLevelPickerSections } from '../data/levels/navigation';
 import {
   buildOccupancyMap,
   canPlacePiece,
@@ -41,6 +42,8 @@ function Game() {
     typeof window === 'undefined' ? 1024 : window.innerWidth,
   );
   const currentLevel = LEVELS[levelIndex];
+  const navigation = useMemo(() => getLevelNavigation(levelIndex), [levelIndex]);
+  const pickerSections = useMemo(() => getLevelPickerSections(), []);
   const currentLevelPieces = useMemo(() => createLevelPieceInstances(currentLevel), [currentLevel]);
   const pieceMap = useMemo(
     () => Object.fromEntries(currentLevelPieces.map((piece) => [piece.id, piece])),
@@ -364,7 +367,7 @@ function Game() {
   });
 
   const hasAnyPlacedPieces = Object.keys(placedPieces).length > 0;
-  const hasNextPuzzle = levelIndex < LEVELS.length - 1;
+  const hasNextPuzzle = navigation?.nextLevelIndex !== null;
   const isRotateActive = Boolean(selectedPieceId || dragState?.pieceId) && !isComplete;
 
   const trayPieces = currentLevelPieces.filter(
@@ -378,7 +381,10 @@ function Game() {
           <div className="game-copy">
             <h1>Cozy Block Prototype</h1>
             <button className="puzzle-trigger" onClick={() => setIsLevelPickerOpen(true)} type="button">
-              Puzzle {levelIndex + 1} of {LEVELS.length}: {currentLevel.name}
+              <span className="puzzle-trigger-set">{navigation.setName}</span>
+              <span className="puzzle-trigger-level">
+                Puzzle {navigation.localLevelNumber} of {navigation.localLevelCount}: {currentLevel.name}
+              </span>
             </button>
           </div>
 
@@ -448,22 +454,36 @@ function Game() {
             <div className="completion-overlay">
               <div className="completion-badge">Yay!</div>
               <div className="completion-copy">
-                You completed
-                <br />
-                Puzzle {levelIndex + 1} of {LEVELS.length}:
-                <br />
-                {currentLevel.name}
+                {navigation.crossesIntoNextSet ? (
+                  <>
+                    You finished
+                    <br />
+                    {navigation.setName}
+                  </>
+                ) : (
+                  <>
+                    You completed
+                    <br />
+                    {navigation.setName}
+                    <br />
+                    Puzzle {navigation.localLevelNumber} of {navigation.localLevelCount}:
+                    <br />
+                    {currentLevel.name}
+                  </>
+                )}
               </div>
               {hasNextPuzzle ? (
                 <button
                   className="completion-next"
-                  onClick={() => goToLevel(levelIndex + 1)}
+                  onClick={() => goToLevel(navigation.nextLevelIndex)}
                   type="button"
                 >
-                  Play the next puzzle
+                  {navigation.crossesIntoNextSet
+                    ? `Start ${navigation.nextSet.name}`
+                    : 'Play the next puzzle'}
                 </button>
               ) : (
-                <div className="completion-done">You finished all puzzles.</div>
+                <div className="completion-done">You finished all worlds.</div>
               )}
             </div>
           ) : null}
@@ -503,17 +523,27 @@ function Game() {
                 Close
               </button>
             </div>
-            <div className="picker-grid">
-              {LEVELS.map((level, index) => (
-                <button
-                  className={index === levelIndex ? 'active' : ''}
-                  key={level.id}
-                  onClick={() => goToLevel(index)}
-                  type="button"
-                >
-                  <span>{index + 1}</span>
-                  <span>{level.name}</span>
-                </button>
+            <div className="picker-sections">
+              {pickerSections.map((section) => (
+                <section className="picker-section" key={section.setId}>
+                  <div className="picker-section-header">
+                    <strong>{section.setName}</strong>
+                    <span>{section.levels.length} puzzles</span>
+                  </div>
+                  <div className="picker-grid">
+                    {section.levels.map(({ level, levelIndex: sectionLevelIndex, localLevelNumber }) => (
+                      <button
+                        className={sectionLevelIndex === levelIndex ? 'active' : ''}
+                        key={level.id}
+                        onClick={() => goToLevel(sectionLevelIndex)}
+                        type="button"
+                      >
+                        <span>Puzzle {localLevelNumber}</span>
+                        <span>{level.name}</span>
+                      </button>
+                    ))}
+                  </div>
+                </section>
               ))}
             </div>
           </div>

--- a/src/data/levels/navigation.js
+++ b/src/data/levels/navigation.js
@@ -1,0 +1,86 @@
+import { LEVELS, LEVEL_SETS } from './index';
+
+function getSetStartIndex(setIndex) {
+  let startIndex = 0;
+
+  for (let index = 0; index < setIndex; index += 1) {
+    startIndex += LEVEL_SETS[index].levels.length;
+  }
+
+  return startIndex;
+}
+
+export function getLevelNavigation(levelIndex) {
+  const level = LEVELS[levelIndex];
+
+  if (!level) {
+    return null;
+  }
+
+  let traversedLevels = 0;
+  let activeSet = null;
+  let activeSetIndex = -1;
+
+  for (let setIndex = 0; setIndex < LEVEL_SETS.length; setIndex += 1) {
+    const set = LEVEL_SETS[setIndex];
+    const nextTraversedLevels = traversedLevels + set.levels.length;
+
+    if (levelIndex < nextTraversedLevels) {
+      activeSet = set;
+      activeSetIndex = setIndex;
+      break;
+    }
+
+    traversedLevels = nextTraversedLevels;
+  }
+
+  if (!activeSet) {
+    return null;
+  }
+
+  const localLevelIndex = levelIndex - traversedLevels;
+  const nextLevelIndex = levelIndex < LEVELS.length - 1 ? levelIndex + 1 : null;
+  const previousLevelIndex = levelIndex > 0 ? levelIndex - 1 : null;
+  const hasNextLevelInSet = localLevelIndex < activeSet.levels.length - 1;
+  const hasPreviousLevelInSet = localLevelIndex > 0;
+  const crossesIntoNextSet = !hasNextLevelInSet && nextLevelIndex !== null;
+  const nextSet = crossesIntoNextSet ? LEVEL_SETS[activeSetIndex + 1] ?? null : null;
+
+  return {
+    levelIndex,
+    level,
+    set: activeSet,
+    setIndex: activeSetIndex,
+    setId: activeSet.id,
+    setName: activeSet.name,
+    localLevelIndex,
+    localLevelNumber: localLevelIndex + 1,
+    localLevelCount: activeSet.levels.length,
+    hasPreviousLevelInSet,
+    hasNextLevelInSet,
+    crossesIntoNextSet,
+    previousLevelIndex,
+    nextLevelIndex,
+    nextSet,
+  };
+}
+
+export function getLevelPickerSections() {
+  return LEVEL_SETS.map((set, setIndex) => {
+    const startLevelIndex = getSetStartIndex(setIndex);
+
+    return {
+      set,
+      setIndex,
+      setId: set.id,
+      setName: set.name,
+      startLevelIndex,
+      levels: set.levels.map((level, localLevelIndex) => ({
+        level,
+        levelIndex: startLevelIndex + localLevelIndex,
+        localLevelIndex,
+        localLevelNumber: localLevelIndex + 1,
+      })),
+    };
+  });
+}

--- a/src/data/levels/navigation.test.js
+++ b/src/data/levels/navigation.test.js
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { getLevelNavigation, getLevelPickerSections } from './navigation';
+
+describe('level navigation helpers', () => {
+  describe('getLevelNavigation', () => {
+    it('reports the correct metadata for the first level of each set', () => {
+      expect(getLevelNavigation(0)).toMatchObject({
+        setId: 'world-0',
+        setName: 'World 0',
+        localLevelIndex: 0,
+        localLevelNumber: 1,
+        localLevelCount: 4,
+        hasPreviousLevelInSet: false,
+      });
+
+      expect(getLevelNavigation(4)).toMatchObject({
+        setId: 'world-1',
+        setName: 'World 1',
+        localLevelIndex: 0,
+        localLevelNumber: 1,
+        localLevelCount: 8,
+        hasPreviousLevelInSet: false,
+      });
+
+      expect(getLevelNavigation(12)).toMatchObject({
+        setId: 'world-2',
+        setName: 'World 2',
+        localLevelIndex: 0,
+        localLevelNumber: 1,
+        localLevelCount: 8,
+        hasPreviousLevelInSet: false,
+      });
+    });
+
+    it('reports the correct metadata for a middle level within a set', () => {
+      expect(getLevelNavigation(6)).toMatchObject({
+        setId: 'world-1',
+        localLevelIndex: 2,
+        localLevelNumber: 3,
+        localLevelCount: 8,
+        hasNextLevelInSet: true,
+        crossesIntoNextSet: false,
+        nextSet: null,
+      });
+    });
+
+    it('reports a set boundary transition at the last level of a non-final set', () => {
+      expect(getLevelNavigation(3)).toMatchObject({
+        setId: 'world-0',
+        localLevelNumber: 4,
+        localLevelCount: 4,
+        hasNextLevelInSet: false,
+        crossesIntoNextSet: true,
+      });
+
+      expect(getLevelNavigation(3)?.nextSet).toMatchObject({
+        id: 'world-1',
+        name: 'World 1',
+      });
+    });
+
+    it('reports no next set at the last level of the final set', () => {
+      expect(getLevelNavigation(19)).toMatchObject({
+        setId: 'world-2',
+        localLevelNumber: 8,
+        localLevelCount: 8,
+        hasNextLevelInSet: false,
+        crossesIntoNextSet: false,
+        nextLevelIndex: null,
+        nextSet: null,
+      });
+    });
+  });
+
+  describe('getLevelPickerSections', () => {
+    it('builds grouped picker sections with the correct local numbering', () => {
+      const sections = getLevelPickerSections().map((section) => ({
+        setId: section.setId,
+        startLevelIndex: section.startLevelIndex,
+        levels: section.levels.slice(0, 2).map((level) => ({
+          levelIndex: level.levelIndex,
+          localLevelNumber: level.localLevelNumber,
+        })),
+      }));
+
+      expect(sections).toEqual([
+        {
+          setId: 'world-0',
+          startLevelIndex: 0,
+          levels: [
+            { levelIndex: 0, localLevelNumber: 1 },
+            { levelIndex: 1, localLevelNumber: 2 },
+          ],
+        },
+        {
+          setId: 'world-1',
+          startLevelIndex: 4,
+          levels: [
+            { levelIndex: 4, localLevelNumber: 1 },
+            { levelIndex: 5, localLevelNumber: 2 },
+          ],
+        },
+        {
+          setId: 'world-2',
+          startLevelIndex: 12,
+          levels: [
+            { levelIndex: 12, localLevelNumber: 1 },
+            { levelIndex: 13, localLevelNumber: 2 },
+          ],
+        },
+      ]);
+    });
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -97,10 +97,27 @@ button {
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .puzzle-trigger:hover {
   color: #143c6f;
+}
+
+.puzzle-trigger-set {
+  font-size: 0.78rem;
+  font-weight: 800;
+  line-height: 1.1;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.puzzle-trigger-level {
+  font-size: 0.8rem;
+  font-weight: 500;
+  line-height: 1.2;
 }
 
 .puzzle-trigger:focus-visible,
@@ -254,6 +271,7 @@ button {
 
 .picker-dialog {
   width: min(100%, 392px);
+  max-height: min(82vh, 720px);
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -282,6 +300,38 @@ button {
   border-radius: 12px;
   background: var(--panel-surface);
   color: var(--text);
+}
+
+.picker-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+
+.picker-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.picker-section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding-inline: 2px;
+}
+
+.picker-section-header strong {
+  font-size: 0.9rem;
+}
+
+.picker-section-header span {
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--text-muted);
 }
 
 .picker-grid {


### PR DESCRIPTION
## Summary
- add a dedicated level navigation module for set-aware traversal metadata
- update the runtime header, completion flow, and picker to show grouped world navigation
- add focused tests for set boundaries and local level numbering

## Verification
- npm test
- npm run build

Closes #4