### PR TITLE
Tighten World 1 board silhouettes

### DIFF
--- a/src/data/levels/world-1/01-long-reach.js
+++ b/src/data/levels/world-1/01-long-reach.js
@@ -4,10 +4,9 @@ const longReach = {
   id: 'world-1-long-reach',
   name: 'Long Reach',
   board: [
-    [1, 1, 1, 1, 1],
-    [1, 1, 0, 0, 0],
-    [1, 0, 0, 0, 0],
-    [1, 1, 0, 0, 0],
+    [1, 1, 1, 1],
+    [1, 1, 1, 1],
+    [0, 0, 1, 1],
   ],
   pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };

--- a/src/data/levels/world-1/02-hook-turn.js
+++ b/src/data/levels/world-1/02-hook-turn.js
@@ -4,10 +4,9 @@ const hookTurn = {
   id: 'world-1-hook-turn',
   name: 'Hook Turn',
   board: [
-    [1, 1, 1, 1, 1],
-    [1, 1, 0, 0, 0],
-    [0, 1, 0, 0, 0],
-    [0, 1, 1, 0, 0],
+    [1, 1, 1, 0],
+    [1, 1, 1, 0],
+    [1, 1, 1, 1],
   ],
   pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };

--- a/src/data/levels/world-1/03-wide-step.js
+++ b/src/data/levels/world-1/03-wide-step.js
@@ -4,10 +4,9 @@ const wideStep = {
   id: 'world-1-wide-step',
   name: 'Wide Step',
   board: [
-    [1, 1, 0, 0, 0],
-    [1, 1, 1, 1, 1],
-    [1, 0, 0, 0, 0],
-    [1, 1, 0, 0, 0],
+    [1, 1, 1, 0],
+    [1, 1, 1, 1],
+    [0, 1, 1, 1],
   ],
   pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };

--- a/src/data/levels/world-1/04-forked-path.js
+++ b/src/data/levels/world-1/04-forked-path.js
@@ -4,10 +4,9 @@ const forkedPath = {
   id: 'world-1-forked-path',
   name: 'Forked Path',
   board: [
-    [1, 1, 0, 0, 0],
-    [1, 1, 1, 1, 1],
-    [0, 1, 0, 0, 0],
-    [0, 1, 1, 0, 0],
+    [1, 1, 1, 0],
+    [1, 0, 1, 1],
+    [1, 1, 1, 1],
   ],
   pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };

--- a/src/data/levels/world-1/05-center-post.js
+++ b/src/data/levels/world-1/05-center-post.js
@@ -4,10 +4,9 @@ const centerPost = {
   id: 'world-1-center-post',
   name: 'Center Post',
   board: [
-    [1, 1, 0, 0, 0],
-    [1, 1, 1, 1, 1],
-    [0, 0, 1, 0, 0],
-    [0, 0, 1, 1, 0],
+    [1, 1, 1, 0],
+    [1, 1, 1, 1],
+    [1, 1, 1, 0],
   ],
   pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };

--- a/src/data/levels/world-1/06-far-corner.js
+++ b/src/data/levels/world-1/06-far-corner.js
@@ -4,10 +4,10 @@ const farCorner = {
   id: 'world-1-far-corner',
   name: 'Far Corner',
   board: [
-    [1, 1, 0, 0, 0],
-    [1, 1, 1, 1, 1],
-    [0, 0, 0, 1, 0],
-    [0, 0, 0, 1, 1],
+    [0, 0, 1, 1],
+    [0, 0, 1, 1],
+    [1, 1, 1, 1],
+    [1, 1, 0, 0],
   ],
   pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };

--- a/src/data/levels/world-1/07-low-bridge.js
+++ b/src/data/levels/world-1/07-low-bridge.js
@@ -4,10 +4,10 @@ const lowBridge = {
   id: 'world-1-low-bridge',
   name: 'Low Bridge',
   board: [
-    [1, 1, 0, 0, 0],
-    [1, 1, 0, 0, 0],
-    [1, 1, 1, 1, 0],
-    [0, 0, 0, 1, 1],
+    [0, 1, 1, 0],
+    [0, 1, 1, 0],
+    [1, 1, 1, 1],
+    [1, 1, 0, 0],
   ],
   pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };

--- a/src/data/levels/world-1/08-split-span.js
+++ b/src/data/levels/world-1/08-split-span.js
@@ -4,10 +4,10 @@ const splitSpan = {
   id: 'world-1-split-span',
   name: 'Split Span',
   board: [
-    [1, 1, 0, 0, 0],
-    [1, 1, 0, 0, 0],
-    [0, 1, 1, 1, 1],
-    [0, 1, 1, 0, 0],
+    [0, 1, 1, 0],
+    [1, 1, 1, 0],
+    [1, 1, 0, 0],
+    [0, 1, 1, 1],
   ],
   pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3],
 };


### PR DESCRIPTION
## Summary\n- replace the most silhouette-driven World 1 boards with tighter compact clusters\n- keep World 1 focused on shape variety with square2, line3, and l3\n- sync the revised boards to the Figma board export/source file for continued critique\n\n## Testing\n- npm test\n- npm run build\n\nCloses #22\n