### PR TITLE
[codex] Trim World 0 to first puzzle

### DIFF
--- a/src/data/levels/levels.validation.test.js
+++ b/src/data/levels/levels.validation.test.js
@@ -141,24 +141,6 @@ describe('level content validation', () => {
         });
       });
     });
-
-    it('only repeats square2 within world 0 levels', () => {
-      LEVELS.forEach((level) => {
-        const pieceCounts = level.pieceIds.reduce((counts, pieceId) => {
-          counts[pieceId] = (counts[pieceId] ?? 0) + 1;
-          return counts;
-        }, {});
-
-        Object.entries(pieceCounts).forEach(([pieceId, count]) => {
-          if (count === 1) {
-            return;
-          }
-
-          expect(getLevelWorldId(level)).toBe('world-0');
-          expect(pieceId).toBe(PIECE_IDS.SQUARE2);
-        });
-      });
-    });
   });
 
   describe('area parity', () => {
@@ -175,18 +157,10 @@ describe('level content validation', () => {
   describe('world pacing rules', () => {
     it('ships the expected world counts for the first content wave', () => {
       expect(LEVEL_SETS.map((set) => [set.id, set.levels.length])).toEqual([
-        ['world-0', 4],
+        ['world-0', 1],
         ['world-1', 8],
         ['world-2', 8],
       ]);
-    });
-
-    it('keeps world 0 limited to repeated square2 pieces', () => {
-      const world0Levels = LEVELS.filter((level) => getLevelWorldId(level) === 'world-0');
-
-      world0Levels.forEach((level) => {
-        expect(level.pieceIds.every((pieceId) => pieceId === PIECE_IDS.SQUARE2)).toBe(true);
-      });
     });
 
     it('keeps world 1 limited to shape variety without requiring rotation', () => {

--- a/src/data/levels/navigation.test.js
+++ b/src/data/levels/navigation.test.js
@@ -9,11 +9,11 @@ describe('level navigation helpers', () => {
         setName: 'World 0',
         localLevelIndex: 0,
         localLevelNumber: 1,
-        localLevelCount: 4,
+        localLevelCount: 1,
         hasPreviousLevelInSet: false,
       });
 
-      expect(getLevelNavigation(4)).toMatchObject({
+      expect(getLevelNavigation(1)).toMatchObject({
         setId: 'world-1',
         setName: 'World 1',
         localLevelIndex: 0,
@@ -22,7 +22,7 @@ describe('level navigation helpers', () => {
         hasPreviousLevelInSet: false,
       });
 
-      expect(getLevelNavigation(12)).toMatchObject({
+      expect(getLevelNavigation(9)).toMatchObject({
         setId: 'world-2',
         setName: 'World 2',
         localLevelIndex: 0,
@@ -33,7 +33,7 @@ describe('level navigation helpers', () => {
     });
 
     it('reports the correct metadata for a middle level within a set', () => {
-      expect(getLevelNavigation(6)).toMatchObject({
+      expect(getLevelNavigation(3)).toMatchObject({
         setId: 'world-1',
         localLevelIndex: 2,
         localLevelNumber: 3,
@@ -45,22 +45,22 @@ describe('level navigation helpers', () => {
     });
 
     it('reports a set boundary transition at the last level of a non-final set', () => {
-      expect(getLevelNavigation(3)).toMatchObject({
+      expect(getLevelNavigation(0)).toMatchObject({
         setId: 'world-0',
-        localLevelNumber: 4,
-        localLevelCount: 4,
+        localLevelNumber: 1,
+        localLevelCount: 1,
         hasNextLevelInSet: false,
         crossesIntoNextSet: true,
       });
 
-      expect(getLevelNavigation(3)?.nextSet).toMatchObject({
+      expect(getLevelNavigation(0)?.nextSet).toMatchObject({
         id: 'world-1',
         name: 'World 1',
       });
     });
 
     it('reports no next set at the last level of the final set', () => {
-      expect(getLevelNavigation(19)).toMatchObject({
+      expect(getLevelNavigation(16)).toMatchObject({
         setId: 'world-2',
         localLevelNumber: 8,
         localLevelCount: 8,
@@ -87,25 +87,22 @@ describe('level navigation helpers', () => {
         {
           setId: 'world-0',
           startLevelIndex: 0,
-          levels: [
-            { levelIndex: 0, localLevelNumber: 1 },
-            { levelIndex: 1, localLevelNumber: 2 },
-          ],
+          levels: [{ levelIndex: 0, localLevelNumber: 1 }],
         },
         {
           setId: 'world-1',
-          startLevelIndex: 4,
+          startLevelIndex: 1,
           levels: [
-            { levelIndex: 4, localLevelNumber: 1 },
-            { levelIndex: 5, localLevelNumber: 2 },
+            { levelIndex: 1, localLevelNumber: 1 },
+            { levelIndex: 2, localLevelNumber: 2 },
           ],
         },
         {
           setId: 'world-2',
-          startLevelIndex: 12,
+          startLevelIndex: 9,
           levels: [
-            { levelIndex: 12, localLevelNumber: 1 },
-            { levelIndex: 13, localLevelNumber: 2 },
+            { levelIndex: 9, localLevelNumber: 1 },
+            { levelIndex: 10, localLevelNumber: 2 },
           ],
         },
       ]);

--- a/src/data/levels/world-0/index.js
+++ b/src/data/levels/world-0/index.js
@@ -1,9 +1,6 @@
 import firstBlock from './01-first-block';
-import twinRooms from './02-twin-rooms';
-import tripleRooms from './03-triple-rooms';
-import fourCorners from './04-four-corners';
 
-const world0Levels = [firstBlock, twinRooms, tripleRooms, fourCorners];
+const world0Levels = [firstBlock];
 
 export const WORLD_0_SET = {
   id: 'world-0',


### PR DESCRIPTION
## Summary
- reduce World 0 to a single puzzle by keeping only First Block in the set
- remove World 0-specific validation rules that encoded the old square-only exception behavior
- update navigation expectations to match the new global level ordering

## Why
World 0 should now act as a one-puzzle intro instead of a four-puzzle special-case set, and the tests should reflect the shared level-set behavior instead of the old exceptions.

## Validation
- npm test -- --run src/data/levels/navigation.test.js src/data/levels/levels.validation.test.js
- npm run build
