### PR TITLE
[codex] Define premium content access

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repo uses a lean GitHub issue and branch workflow.
 5. Link the issue in the PR body and use a closing keyword such as `Closes #123`.
 6. Merge to `main` to trigger the Netlify production deploy.
 
-Netlify deploys `main` to production and automatically creates preview deploys for pull requests.
+Netlify deploys only `main` to production. Pull requests do not create Netlify preview deploys.
 
 Direct pushes to `main` are not the default path and should be reserved for true emergencies.
 

--- a/src/data/levels/access.js
+++ b/src/data/levels/access.js
@@ -1,0 +1,4 @@
+export const LEVEL_ACCESS = {
+  FREE: 'free',
+  PREMIUM: 'premium',
+};

--- a/src/data/levels/index.js
+++ b/src/data/levels/index.js
@@ -1,4 +1,5 @@
 import { PIECE_LIBRARY } from '../pieces';
+export { LEVEL_ACCESS } from './access';
 import WORLD_0_SET from './world-0';
 import WORLD_1_SET from './world-1';
 import WORLD_2_SET from './world-2';

--- a/src/data/levels/levels.validation.test.js
+++ b/src/data/levels/levels.validation.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createLevelPieceInstances, LEVELS, LEVEL_SETS } from './index';
+import { createLevelPieceInstances, LEVELS, LEVEL_ACCESS, LEVEL_SETS } from './index';
 import { PIECE_IDS, PIECE_LIBRARY } from '../pieces';
 import { canPlacePiece, placePiece, rotateShape } from '../../utils/grid';
 
@@ -73,7 +73,7 @@ function solveLevel(level) {
 
 describe('level content validation', () => {
   describe('set structure', () => {
-    it('defines sets with ids, names, and non-empty level arrays', () => {
+    it('defines sets with ids, names, access, and non-empty level arrays', () => {
       expect(LEVEL_SETS.length).toBeGreaterThan(0);
 
       LEVEL_SETS.forEach((set) => {
@@ -81,6 +81,7 @@ describe('level content validation', () => {
         expect(set.id.length).toBeGreaterThan(0);
         expect(typeof set.name).toBe('string');
         expect(set.name.length).toBeGreaterThan(0);
+        expect(Object.values(LEVEL_ACCESS)).toContain(set.access);
         expect(Array.isArray(set.levels)).toBe(true);
         expect(set.levels.length).toBeGreaterThan(0);
       });
@@ -155,6 +156,14 @@ describe('level content validation', () => {
   });
 
   describe('world pacing rules', () => {
+    it('ships the expected free and premium access split for the first content wave', () => {
+      expect(LEVEL_SETS.map((set) => [set.id, set.access])).toEqual([
+        ['world-0', LEVEL_ACCESS.FREE],
+        ['world-1', LEVEL_ACCESS.FREE],
+        ['world-2', LEVEL_ACCESS.PREMIUM],
+      ]);
+    });
+
     it('ships the expected world counts for the first content wave', () => {
       expect(LEVEL_SETS.map((set) => [set.id, set.levels.length])).toEqual([
         ['world-0', 1],

--- a/src/data/levels/world-0/index.js
+++ b/src/data/levels/world-0/index.js
@@ -1,3 +1,4 @@
+import { LEVEL_ACCESS } from '../access';
 import firstBlock from './01-first-block';
 
 const world0Levels = [firstBlock];
@@ -5,6 +6,7 @@ const world0Levels = [firstBlock];
 export const WORLD_0_SET = {
   id: 'world-0',
   name: 'World 0',
+  access: LEVEL_ACCESS.FREE,
   levels: world0Levels,
 };
 

--- a/src/data/levels/world-1/index.js
+++ b/src/data/levels/world-1/index.js
@@ -1,3 +1,4 @@
+import { LEVEL_ACCESS } from '../access';
 import centerPost from './05-center-post';
 import farCorner from './06-far-corner';
 import forkedPath from './04-forked-path';
@@ -21,6 +22,7 @@ const world1Levels = [
 export const WORLD_1_SET = {
   id: 'world-1',
   name: 'World 1',
+  access: LEVEL_ACCESS.FREE,
   levels: world1Levels,
 };
 

--- a/src/data/levels/world-2/index.js
+++ b/src/data/levels/world-2/index.js
@@ -1,3 +1,4 @@
+import { LEVEL_ACCESS } from '../access';
 import bentRoute from './04-bent-route';
 import cornerSpin from './05-corner-spin';
 import crosswind from './07-crosswind';
@@ -21,6 +22,7 @@ const world2Levels = [
 export const WORLD_2_SET = {
   id: 'world-2',
   name: 'World 2',
+  access: LEVEL_ACCESS.PREMIUM,
   levels: world2Levels,
 };
 


### PR DESCRIPTION
## Summary
- add shared free vs premium level access constants in content data
- mark world sets with access metadata and re-export the contract for downstream navigation work
- document the current Netlify main-only deploy policy

## Why
Issue #28 moves the free vs premium split into level content so later paywall-aware navigation can read one source of truth instead of scattering access rules through gameplay code.

## Validation
- npm run validate:levels
- npm run build

Closes #28