### PR TITLE
[codex] Add paywall-aware navigation

### DIFF
--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -19,7 +19,21 @@ function createInitialTrayRotations(levelPieces) {
   return Object.fromEntries(levelPieces.map((piece) => [piece.id, 0]));
 }
 
+function createBlockedModalState(target, source) {
+  if (!target || target.blockedAction === 'none') {
+    return null;
+  }
+
+  return {
+    targetSetId: target.setId,
+    targetSetName: target.setName,
+    source,
+    action: target.blockedAction,
+  };
+}
+
 function Game() {
+  const hasPremium = false;
   const boardRef = useRef(null);
   const trayRef = useRef(null);
   const dragStateRef = useRef(null);
@@ -38,12 +52,16 @@ function Game() {
   const [selectedPieceId, setSelectedPieceId] = useState(null);
   const [dragState, setDragState] = useState(null);
   const [isLevelPickerOpen, setIsLevelPickerOpen] = useState(false);
+  const [blockedModalState, setBlockedModalState] = useState(null);
   const [viewportWidth, setViewportWidth] = useState(
     typeof window === 'undefined' ? 1024 : window.innerWidth,
   );
   const currentLevel = LEVELS[levelIndex];
-  const navigation = useMemo(() => getLevelNavigation(levelIndex), [levelIndex]);
-  const pickerSections = useMemo(() => getLevelPickerSections(), []);
+  const navigation = useMemo(
+    () => getLevelNavigation(levelIndex, { hasPremium }),
+    [hasPremium, levelIndex],
+  );
+  const pickerSections = useMemo(() => getLevelPickerSections({ hasPremium }), [hasPremium]);
   const currentLevelPieces = useMemo(() => createLevelPieceInstances(currentLevel), [currentLevel]);
   const pieceMap = useMemo(
     () => Object.fromEntries(currentLevelPieces.map((piece) => [piece.id, piece])),
@@ -302,6 +320,56 @@ function Game() {
     resetLevelState(LEVELS[nextIndex]);
     setLevelIndex(nextIndex);
     setIsLevelPickerOpen(false);
+    setBlockedModalState(null);
+  };
+
+  const openBlockedModal = (target, source) => {
+    const nextBlockedModalState = createBlockedModalState(target, source);
+
+    if (!nextBlockedModalState) {
+      return;
+    }
+
+    setIsLevelPickerOpen(false);
+    setBlockedModalState(nextBlockedModalState);
+  };
+
+  const closeBlockedModal = () => {
+    setBlockedModalState(null);
+  };
+
+  const showRestorePlaceholder = () => {
+    setBlockedModalState((currentBlockedModalState) =>
+      currentBlockedModalState ? { ...currentBlockedModalState, action: 'show_restore' } : null,
+    );
+  };
+
+  const showPurchasePlaceholder = () => {
+    setBlockedModalState((currentBlockedModalState) =>
+      currentBlockedModalState ? { ...currentBlockedModalState, action: 'show_purchase' } : null,
+    );
+  };
+
+  const handleLevelPickerSelection = (level) => {
+    if (!level.isAccessible) {
+      openBlockedModal(level, 'picker');
+      return;
+    }
+
+    goToLevel(level.levelIndex);
+  };
+
+  const handleNextPuzzle = () => {
+    if (!navigation?.nextTarget) {
+      return;
+    }
+
+    if (!navigation.nextTarget.isAccessible) {
+      openBlockedModal(navigation.nextTarget, 'next_level');
+      return;
+    }
+
+    goToLevel(navigation.nextTarget.levelIndex);
   };
 
   useEffect(() => {
@@ -350,6 +418,11 @@ function Game() {
   useEffect(() => {
     const handleKeyDown = (event) => {
       if (event.key === 'Escape') {
+        if (blockedModalState) {
+          closeBlockedModal();
+          return;
+        }
+
         setIsLevelPickerOpen(false);
         return;
       }
@@ -364,10 +437,10 @@ function Game() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  });
+  }, [blockedModalState]);
 
   const hasAnyPlacedPieces = Object.keys(placedPieces).length > 0;
-  const hasNextPuzzle = navigation?.nextLevelIndex !== null;
+  const hasNextPuzzle = navigation?.nextTarget !== null;
   const isRotateActive = Boolean(selectedPieceId || dragState?.pieceId) && !isComplete;
 
   const trayPieces = currentLevelPieces.filter(
@@ -475,7 +548,7 @@ function Game() {
               {hasNextPuzzle ? (
                 <button
                   className="completion-next"
-                  onClick={() => goToLevel(navigation.nextLevelIndex)}
+                  onClick={handleNextPuzzle}
                   type="button"
                 >
                   {navigation.crossesIntoNextSet
@@ -531,21 +604,81 @@ function Game() {
                     <span>{section.levels.length} puzzles</span>
                   </div>
                   <div className="picker-grid">
-                    {section.levels.map(({ level, levelIndex: sectionLevelIndex, localLevelNumber }) => (
+                    {section.levels.map((level) => (
                       <button
-                        className={sectionLevelIndex === levelIndex ? 'active' : ''}
-                        key={level.id}
-                        onClick={() => goToLevel(sectionLevelIndex)}
+                        aria-disabled={!level.isAccessible}
+                        className={[
+                          level.levelIndex === levelIndex ? 'active' : '',
+                          !level.isAccessible ? 'is-locked' : '',
+                        ]
+                          .filter(Boolean)
+                          .join(' ')}
+                        key={level.level.id}
+                        onClick={() => handleLevelPickerSelection(level)}
                         type="button"
                       >
-                        <span>Puzzle {localLevelNumber}</span>
-                        <span>{level.name}</span>
+                        <span className="picker-grid-meta">
+                          <span>Puzzle {level.localLevelNumber}</span>
+                          {!level.isAccessible ? (
+                            <span className="picker-premium-badge">Premium</span>
+                          ) : null}
+                        </span>
+                        <span>{level.level.name}</span>
                       </button>
                     ))}
                   </div>
                 </section>
               ))}
             </div>
+          </div>
+        </div>
+      ) : null}
+
+      {blockedModalState ? (
+        <div className="picker-backdrop" onClick={closeBlockedModal} role="presentation">
+          <div
+            aria-label="Premium content locked"
+            aria-modal="true"
+            className="blocked-dialog"
+            onClick={(event) => event.stopPropagation()}
+            role="dialog"
+          >
+            <div className="picker-header">
+              <div>
+                <strong>Premium Content</strong>
+              </div>
+              <button onClick={closeBlockedModal} type="button">
+                Close
+              </button>
+            </div>
+
+            {blockedModalState.action === 'show_restore' ? (
+              <div className="blocked-dialog-body">
+                <p className="blocked-dialog-copy">
+                  Restore for {blockedModalState.targetSetName} is coming next. This placeholder
+                  confirms the locked flow without wiring the real restore form yet.
+                </p>
+                <button className="blocked-dialog-primary" onClick={showPurchasePlaceholder} type="button">
+                  Back to premium details
+                </button>
+              </div>
+            ) : (
+              <div className="blocked-dialog-body">
+                <div className="blocked-dialog-kicker">
+                  {blockedModalState.source === 'next_level' ? 'Next world locked' : 'Locked from picker'}
+                </div>
+                <p className="blocked-dialog-copy">
+                  {blockedModalState.targetSetName} is premium content. Buying and restore are not wired in
+                  yet, but this placeholder blocks entry and keeps the locked-state behavior visible.
+                </p>
+                <button className="blocked-dialog-primary" type="button">
+                  Buy placeholder
+                </button>
+                <button className="blocked-dialog-secondary" onClick={showRestorePlaceholder} type="button">
+                  Restore placeholder
+                </button>
+              </div>
+            )}
           </div>
         </div>
       ) : null}

--- a/src/data/levels/navigation.js
+++ b/src/data/levels/navigation.js
@@ -1,4 +1,35 @@
-import { LEVELS, LEVEL_SETS } from './index';
+import { LEVEL_ACCESS, LEVELS, LEVEL_SETS } from './index';
+
+function getSetAccessState(set, { hasPremium = false } = {}) {
+  const isAccessible = hasPremium || set.access !== LEVEL_ACCESS.PREMIUM;
+
+  return {
+    access: set.access,
+    isAccessible,
+    blockedAction: isAccessible ? 'none' : 'show_purchase',
+  };
+}
+
+function getSetContext(levelIndex) {
+  let traversedLevels = 0;
+
+  for (let setIndex = 0; setIndex < LEVEL_SETS.length; setIndex += 1) {
+    const set = LEVEL_SETS[setIndex];
+    const nextTraversedLevels = traversedLevels + set.levels.length;
+
+    if (levelIndex < nextTraversedLevels) {
+      return {
+        set,
+        setIndex,
+        startLevelIndex: traversedLevels,
+      };
+    }
+
+    traversedLevels = nextTraversedLevels;
+  }
+
+  return null;
+}
 
 function getSetStartIndex(setIndex) {
   let startIndex = 0;
@@ -10,41 +41,39 @@ function getSetStartIndex(setIndex) {
   return startIndex;
 }
 
-export function getLevelNavigation(levelIndex) {
+export function getLevelNavigation(levelIndex, options = {}) {
   const level = LEVELS[levelIndex];
 
   if (!level) {
     return null;
   }
 
-  let traversedLevels = 0;
-  let activeSet = null;
-  let activeSetIndex = -1;
+  const activeSetContext = getSetContext(levelIndex);
 
-  for (let setIndex = 0; setIndex < LEVEL_SETS.length; setIndex += 1) {
-    const set = LEVEL_SETS[setIndex];
-    const nextTraversedLevels = traversedLevels + set.levels.length;
-
-    if (levelIndex < nextTraversedLevels) {
-      activeSet = set;
-      activeSetIndex = setIndex;
-      break;
-    }
-
-    traversedLevels = nextTraversedLevels;
-  }
-
-  if (!activeSet) {
+  if (!activeSetContext) {
     return null;
   }
 
-  const localLevelIndex = levelIndex - traversedLevels;
+  const { set: activeSet, setIndex: activeSetIndex, startLevelIndex } = activeSetContext;
+  const activeSetAccessState = getSetAccessState(activeSet, options);
+  const localLevelIndex = levelIndex - startLevelIndex;
   const nextLevelIndex = levelIndex < LEVELS.length - 1 ? levelIndex + 1 : null;
   const previousLevelIndex = levelIndex > 0 ? levelIndex - 1 : null;
   const hasNextLevelInSet = localLevelIndex < activeSet.levels.length - 1;
   const hasPreviousLevelInSet = localLevelIndex > 0;
   const crossesIntoNextSet = !hasNextLevelInSet && nextLevelIndex !== null;
-  const nextSet = crossesIntoNextSet ? LEVEL_SETS[activeSetIndex + 1] ?? null : null;
+  const nextTargetContext = nextLevelIndex !== null ? getSetContext(nextLevelIndex) : null;
+  const nextSet = crossesIntoNextSet ? nextTargetContext?.set ?? null : null;
+  const nextTarget = nextTargetContext
+    ? {
+        levelIndex: nextLevelIndex,
+        set: nextTargetContext.set,
+        setIndex: nextTargetContext.setIndex,
+        setId: nextTargetContext.set.id,
+        setName: nextTargetContext.set.name,
+        ...getSetAccessState(nextTargetContext.set, options),
+      }
+    : null;
 
   return {
     levelIndex,
@@ -53,6 +82,7 @@ export function getLevelNavigation(levelIndex) {
     setIndex: activeSetIndex,
     setId: activeSet.id,
     setName: activeSet.name,
+    ...activeSetAccessState,
     localLevelIndex,
     localLevelNumber: localLevelIndex + 1,
     localLevelCount: activeSet.levels.length,
@@ -62,24 +92,30 @@ export function getLevelNavigation(levelIndex) {
     previousLevelIndex,
     nextLevelIndex,
     nextSet,
+    nextTarget,
   };
 }
 
-export function getLevelPickerSections() {
+export function getLevelPickerSections(options = {}) {
   return LEVEL_SETS.map((set, setIndex) => {
     const startLevelIndex = getSetStartIndex(setIndex);
+    const setAccessState = getSetAccessState(set, options);
 
     return {
       set,
       setIndex,
       setId: set.id,
       setName: set.name,
+      ...setAccessState,
       startLevelIndex,
       levels: set.levels.map((level, localLevelIndex) => ({
         level,
         levelIndex: startLevelIndex + localLevelIndex,
         localLevelIndex,
         localLevelNumber: localLevelIndex + 1,
+        setId: set.id,
+        setName: set.name,
+        ...setAccessState,
       })),
     };
   });

--- a/src/data/levels/navigation.test.js
+++ b/src/data/levels/navigation.test.js
@@ -7,6 +7,9 @@ describe('level navigation helpers', () => {
       expect(getLevelNavigation(0)).toMatchObject({
         setId: 'world-0',
         setName: 'World 0',
+        access: 'free',
+        isAccessible: true,
+        blockedAction: 'none',
         localLevelIndex: 0,
         localLevelNumber: 1,
         localLevelCount: 1,
@@ -16,6 +19,9 @@ describe('level navigation helpers', () => {
       expect(getLevelNavigation(1)).toMatchObject({
         setId: 'world-1',
         setName: 'World 1',
+        access: 'free',
+        isAccessible: true,
+        blockedAction: 'none',
         localLevelIndex: 0,
         localLevelNumber: 1,
         localLevelCount: 8,
@@ -25,6 +31,9 @@ describe('level navigation helpers', () => {
       expect(getLevelNavigation(9)).toMatchObject({
         setId: 'world-2',
         setName: 'World 2',
+        access: 'premium',
+        isAccessible: false,
+        blockedAction: 'show_purchase',
         localLevelIndex: 0,
         localLevelNumber: 1,
         localLevelCount: 8,
@@ -59,6 +68,23 @@ describe('level navigation helpers', () => {
       });
     });
 
+    it('reports blocked next-target metadata when a free player reaches premium content', () => {
+      expect(getLevelNavigation(8)).toMatchObject({
+        setId: 'world-1',
+        setName: 'World 1',
+        crossesIntoNextSet: true,
+      });
+
+      expect(getLevelNavigation(8)?.nextTarget).toMatchObject({
+        levelIndex: 9,
+        setId: 'world-2',
+        setName: 'World 2',
+        access: 'premium',
+        isAccessible: false,
+        blockedAction: 'show_purchase',
+      });
+    });
+
     it('reports no next set at the last level of the final set', () => {
       expect(getLevelNavigation(16)).toMatchObject({
         setId: 'world-2',
@@ -68,6 +94,22 @@ describe('level navigation helpers', () => {
         crossesIntoNextSet: false,
         nextLevelIndex: null,
         nextSet: null,
+      });
+    });
+
+    it('reports premium worlds as accessible for premium players', () => {
+      expect(getLevelNavigation(9, { hasPremium: true })).toMatchObject({
+        setId: 'world-2',
+        access: 'premium',
+        isAccessible: true,
+        blockedAction: 'none',
+      });
+
+      expect(getLevelNavigation(8, { hasPremium: true })?.nextTarget).toMatchObject({
+        levelIndex: 9,
+        setId: 'world-2',
+        isAccessible: true,
+        blockedAction: 'none',
       });
     });
   });
@@ -106,6 +148,46 @@ describe('level navigation helpers', () => {
           ],
         },
       ]);
+    });
+
+    it('marks premium sections and levels as inaccessible for free players', () => {
+      const premiumSection = getLevelPickerSections().find((section) => section.setId === 'world-2');
+
+      expect(premiumSection).toMatchObject({
+        setId: 'world-2',
+        access: 'premium',
+        isAccessible: false,
+        blockedAction: 'show_purchase',
+      });
+
+      expect(premiumSection?.levels[0]).toMatchObject({
+        levelIndex: 9,
+        setId: 'world-2',
+        setName: 'World 2',
+        access: 'premium',
+        isAccessible: false,
+        blockedAction: 'show_purchase',
+      });
+    });
+
+    it('marks premium sections and levels as accessible for premium players', () => {
+      const premiumSection = getLevelPickerSections({ hasPremium: true }).find(
+        (section) => section.setId === 'world-2',
+      );
+
+      expect(premiumSection).toMatchObject({
+        setId: 'world-2',
+        access: 'premium',
+        isAccessible: true,
+        blockedAction: 'none',
+      });
+
+      expect(premiumSection?.levels[0]).toMatchObject({
+        levelIndex: 9,
+        access: 'premium',
+        isAccessible: true,
+        blockedAction: 'none',
+      });
     });
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -125,7 +125,9 @@ button {
 .picker-header button:focus-visible,
 .picker-grid button:focus-visible,
 .bubble-reset:focus-visible,
-.bubble-rotate:focus-visible {
+.bubble-rotate:focus-visible,
+.blocked-dialog-primary:focus-visible,
+.blocked-dialog-secondary:focus-visible {
   outline: 2px solid var(--accent-dark);
   outline-offset: 3px;
 }
@@ -353,10 +355,95 @@ button {
   font-weight: 800;
 }
 
+.picker-grid-meta {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.picker-premium-badge {
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: rgba(31, 90, 166, 0.1);
+  color: var(--accent-dark);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
 .picker-grid button.active {
   background: var(--accent);
   color: #ffffff;
   border-color: var(--accent);
+}
+
+.picker-grid button.is-locked {
+  border-style: dashed;
+  color: var(--text-muted);
+}
+
+.picker-grid button.is-locked.active {
+  border-color: var(--panel-border);
+  background: var(--panel-surface);
+  color: var(--text-muted);
+}
+
+.blocked-dialog {
+  width: min(100%, 392px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px 14px;
+  border: 6px solid var(--accent);
+  border-radius: 22px;
+  background: var(--card-surface);
+  box-shadow: 0 18px 40px var(--shadow);
+}
+
+.blocked-dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.blocked-dialog-kicker {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent-dark);
+}
+
+.blocked-dialog-copy {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.88rem;
+  line-height: 1.35;
+}
+
+.blocked-dialog-primary,
+.blocked-dialog-secondary {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.blocked-dialog-primary {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.blocked-dialog-secondary {
+  border: 1px solid var(--panel-border);
+  background: var(--panel-surface);
+  color: var(--text);
 }
 
 .board-shell {


### PR DESCRIPTION
## Summary
- add entitlement-aware navigation metadata for current sets, next targets, and picker entries
- block free-player entry into premium worlds from both the picker and the completion CTA
- add a lightweight placeholder premium modal so locked-state behavior is visible before the full purchase/restore UX lands

## Why
Production should not silently enter premium content once world access exists in the data model. This PR adds the minimal navigation and blocked-state behavior needed to enforce the free/premium boundary, while keeping real purchase and restore flows deferred to follow-up work.

## Notes
- this PR intentionally uses a temporary `hasPremium = false` stub in the app
- the premium modal is a placeholder and should not ship to production on its own
- hold merge until the follow-up premium UX work is ready to replace the placeholder actions

## Validation
- `npx vitest run src/data/levels/navigation.test.js`
- `npm run build`
- local manual smoke test: picker blocked modal displayed and closed correctly

Closes #29
