### PR TITLE
[codex] Author worlds 3-8 level expansion

### DIFF
--- a/src/data/levels/index.js
+++ b/src/data/levels/index.js
@@ -3,6 +3,12 @@ export { LEVEL_ACCESS } from './access';
 import WORLD_0_SET from './world-0';
 import WORLD_1_SET from './world-1';
 import WORLD_2_SET from './world-2';
+import WORLD_3_SET from './world-3';
+import WORLD_4_SET from './world-4';
+import WORLD_5_SET from './world-5';
+import WORLD_6_SET from './world-6';
+import WORLD_7_SET from './world-7';
+import WORLD_8_SET from './world-8';
 
 export function createLevelPieceInstances(level) {
   const pieceCounts = {};
@@ -25,6 +31,16 @@ export function createLevelPieceInstances(level) {
     .filter(Boolean);
 }
 
-export const LEVEL_SETS = [WORLD_0_SET, WORLD_1_SET, WORLD_2_SET];
+export const LEVEL_SETS = [
+  WORLD_0_SET,
+  WORLD_1_SET,
+  WORLD_2_SET,
+  WORLD_3_SET,
+  WORLD_4_SET,
+  WORLD_5_SET,
+  WORLD_6_SET,
+  WORLD_7_SET,
+  WORLD_8_SET,
+];
 
 export const LEVELS = LEVEL_SETS.flatMap((set) => set.levels);

--- a/src/data/levels/levels.validation.test.js
+++ b/src/data/levels/levels.validation.test.js
@@ -16,6 +16,10 @@ function getLevelWorldId(level) {
   return level.id.split('-').slice(0, 2).join('-');
 }
 
+function getWorldLevels(worldId) {
+  return LEVELS.filter((level) => getLevelWorldId(level) === worldId);
+}
+
 function getDistinctRotations(shape) {
   const rotations = [];
   const seen = new Set();
@@ -161,14 +165,26 @@ describe('level content validation', () => {
         ['world-0', LEVEL_ACCESS.FREE],
         ['world-1', LEVEL_ACCESS.FREE],
         ['world-2', LEVEL_ACCESS.PREMIUM],
+        ['world-3', LEVEL_ACCESS.PREMIUM],
+        ['world-4', LEVEL_ACCESS.PREMIUM],
+        ['world-5', LEVEL_ACCESS.PREMIUM],
+        ['world-6', LEVEL_ACCESS.PREMIUM],
+        ['world-7', LEVEL_ACCESS.PREMIUM],
+        ['world-8', LEVEL_ACCESS.PREMIUM],
       ]);
     });
 
-    it('ships the expected world counts for the first content wave', () => {
+    it('ships the expected world counts for the current content wave', () => {
       expect(LEVEL_SETS.map((set) => [set.id, set.levels.length])).toEqual([
         ['world-0', 1],
         ['world-1', 8],
         ['world-2', 8],
+        ['world-3', 8],
+        ['world-4', 8],
+        ['world-5', 8],
+        ['world-6', 8],
+        ['world-7', 8],
+        ['world-8', 8],
       ]);
     });
 
@@ -192,7 +208,7 @@ describe('level content validation', () => {
 
     it('makes world 2 require a rotated t4 placement', () => {
       const allowedPieces = [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4];
-      const world2Levels = LEVELS.filter((level) => getLevelWorldId(level) === 'world-2');
+      const world2Levels = getWorldLevels('world-2');
 
       world2Levels.forEach((level) => {
         expect(level.pieceIds).toEqual(allowedPieces);
@@ -206,6 +222,83 @@ describe('level content validation', () => {
         });
 
         expect(allSolutionsRotateT4).toBe(true);
+      });
+    });
+
+    it('uses the world 2 piece set unchanged while world 3 stretches the boards', () => {
+      const allowedPieces = [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4];
+      const world3Levels = getWorldLevels('world-3');
+
+      world3Levels.forEach((level) => {
+        expect(level.pieceIds).toEqual(allowedPieces);
+      });
+
+      world3Levels.slice(0, 4).forEach((level) => {
+        const maxDimension = Math.max(level.board.length, ...level.board.map((row) => row.length));
+        expect(maxDimension).toBeLessThanOrEqual(5);
+      });
+
+      world3Levels.slice(4).forEach((level) => {
+        const maxDimension = Math.max(level.board.length, ...level.board.map((row) => row.length));
+        expect(maxDimension).toBeGreaterThanOrEqual(5);
+      });
+
+      const stretchedLevels = world3Levels.filter(
+        (level) => Math.max(level.board.length, ...level.board.map((row) => row.length)) >= 6,
+      );
+      expect(stretchedLevels.length).toBeGreaterThan(0);
+    });
+
+    it('introduces line4 in world 4 and keeps the same set through world 5', () => {
+      const allowedPieces = [
+        PIECE_IDS.SQUARE2,
+        PIECE_IDS.LINE3,
+        PIECE_IDS.L3,
+        PIECE_IDS.T4,
+        PIECE_IDS.LINE4,
+      ];
+
+      ['world-4', 'world-5'].forEach((worldId) => {
+        getWorldLevels(worldId).forEach((level) => {
+          expect(level.pieceIds).toEqual(allowedPieces);
+        });
+      });
+    });
+
+    it('introduces z4 in world 6 and keeps the same set through world 7', () => {
+      const allowedPieces = [
+        PIECE_IDS.SQUARE2,
+        PIECE_IDS.LINE3,
+        PIECE_IDS.L3,
+        PIECE_IDS.T4,
+        PIECE_IDS.LINE4,
+        PIECE_IDS.Z4,
+      ];
+
+      ['world-6', 'world-7'].forEach((worldId) => {
+        getWorldLevels(worldId).forEach((level) => {
+          expect(level.pieceIds).toEqual(allowedPieces);
+        });
+      });
+    });
+
+    it('introduces s4 in world 8 for denser layouts', () => {
+      const allowedPieces = [
+        PIECE_IDS.SQUARE2,
+        PIECE_IDS.LINE3,
+        PIECE_IDS.L3,
+        PIECE_IDS.T4,
+        PIECE_IDS.LINE4,
+        PIECE_IDS.Z4,
+        PIECE_IDS.S4,
+      ];
+      const world8Levels = getWorldLevels('world-8');
+
+      world8Levels.forEach((level) => {
+        expect(level.pieceIds).toEqual(allowedPieces);
+        const boardArea = countPlayableCells(level.board);
+        const boxArea = level.board.length * Math.max(...level.board.map((row) => row.length));
+        expect(boardArea / boxArea).toBeGreaterThanOrEqual(0.6);
       });
     });
   });

--- a/src/data/levels/navigation.test.js
+++ b/src/data/levels/navigation.test.js
@@ -30,6 +30,24 @@ describe('level navigation helpers', () => {
         localLevelCount: 8,
         hasPreviousLevelInSet: false,
       });
+
+      expect(getLevelNavigation(17)).toMatchObject({
+        setId: 'world-3',
+        setName: 'World 3',
+        localLevelIndex: 0,
+        localLevelNumber: 1,
+        localLevelCount: 8,
+        hasPreviousLevelInSet: false,
+      });
+
+      expect(getLevelNavigation(57)).toMatchObject({
+        setId: 'world-8',
+        setName: 'World 8',
+        localLevelIndex: 0,
+        localLevelNumber: 1,
+        localLevelCount: 8,
+        hasPreviousLevelInSet: false,
+      });
     });
 
     it('reports the correct metadata for a middle level within a set', () => {
@@ -60,8 +78,8 @@ describe('level navigation helpers', () => {
     });
 
     it('reports no next set at the last level of the final set', () => {
-      expect(getLevelNavigation(16)).toMatchObject({
-        setId: 'world-2',
+      expect(getLevelNavigation(64)).toMatchObject({
+        setId: 'world-8',
         localLevelNumber: 8,
         localLevelCount: 8,
         hasNextLevelInSet: false,
@@ -103,6 +121,54 @@ describe('level navigation helpers', () => {
           levels: [
             { levelIndex: 9, localLevelNumber: 1 },
             { levelIndex: 10, localLevelNumber: 2 },
+          ],
+        },
+        {
+          setId: 'world-3',
+          startLevelIndex: 17,
+          levels: [
+            { levelIndex: 17, localLevelNumber: 1 },
+            { levelIndex: 18, localLevelNumber: 2 },
+          ],
+        },
+        {
+          setId: 'world-4',
+          startLevelIndex: 25,
+          levels: [
+            { levelIndex: 25, localLevelNumber: 1 },
+            { levelIndex: 26, localLevelNumber: 2 },
+          ],
+        },
+        {
+          setId: 'world-5',
+          startLevelIndex: 33,
+          levels: [
+            { levelIndex: 33, localLevelNumber: 1 },
+            { levelIndex: 34, localLevelNumber: 2 },
+          ],
+        },
+        {
+          setId: 'world-6',
+          startLevelIndex: 41,
+          levels: [
+            { levelIndex: 41, localLevelNumber: 1 },
+            { levelIndex: 42, localLevelNumber: 2 },
+          ],
+        },
+        {
+          setId: 'world-7',
+          startLevelIndex: 49,
+          levels: [
+            { levelIndex: 49, localLevelNumber: 1 },
+            { levelIndex: 50, localLevelNumber: 2 },
+          ],
+        },
+        {
+          setId: 'world-8',
+          startLevelIndex: 57,
+          levels: [
+            { levelIndex: 57, localLevelNumber: 1 },
+            { levelIndex: 58, localLevelNumber: 2 },
           ],
         },
       ]);

--- a/src/data/levels/world-3/01-long-porch.js
+++ b/src/data/levels/world-3/01-long-porch.js
@@ -1,0 +1,14 @@
+import { PIECE_IDS } from '../../pieces';
+
+const longPorch = {
+  id: 'world-3-long-porch',
+  name: 'Long Porch',
+  board: [
+    [1, 1, 1, 1, 0],
+    [1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4],
+};
+
+export default longPorch;

--- a/src/data/levels/world-3/02-tall-stack.js
+++ b/src/data/levels/world-3/02-tall-stack.js
@@ -1,0 +1,16 @@
+import { PIECE_IDS } from '../../pieces';
+
+const tallStack = {
+  id: 'world-3-tall-stack',
+  name: 'Tall Stack',
+  board: [
+    [1, 1, 1],
+    [1, 1, 1],
+    [1, 1, 1],
+    [1, 1, 1],
+    [0, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4],
+};
+
+export default tallStack;

--- a/src/data/levels/world-3/03-open-step.js
+++ b/src/data/levels/world-3/03-open-step.js
@@ -1,0 +1,15 @@
+import { PIECE_IDS } from '../../pieces';
+
+const openStep = {
+  id: 'world-3-open-step',
+  name: 'Open Step',
+  board: [
+    [1, 1, 1, 0],
+    [1, 1, 1, 1],
+    [1, 1, 1, 1],
+    [1, 1, 1, 0],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4],
+};
+
+export default openStep;

--- a/src/data/levels/world-3/04-bend-ahead.js
+++ b/src/data/levels/world-3/04-bend-ahead.js
@@ -1,0 +1,15 @@
+import { PIECE_IDS } from '../../pieces';
+
+const bendAhead = {
+  id: 'world-3-bend-ahead',
+  name: 'Bend Ahead',
+  board: [
+    [1, 1, 1, 1, 1],
+    [1, 1, 0, 1, 1],
+    [1, 1, 0, 0, 0],
+    [1, 1, 1, 0, 0],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4],
+};
+
+export default bendAhead;

--- a/src/data/levels/world-3/05-long-ladder.js
+++ b/src/data/levels/world-3/05-long-ladder.js
@@ -1,0 +1,17 @@
+import { PIECE_IDS } from '../../pieces';
+
+const longLadder = {
+  id: 'world-3-long-ladder',
+  name: 'Long Ladder',
+  board: [
+    [0, 0, 1],
+    [0, 1, 1],
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+    [1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4],
+};
+
+export default longLadder;

--- a/src/data/levels/world-3/06-narrow-reach.js
+++ b/src/data/levels/world-3/06-narrow-reach.js
@@ -1,0 +1,16 @@
+import { PIECE_IDS } from '../../pieces';
+
+const narrowReach = {
+  id: 'world-3-narrow-reach',
+  name: 'Narrow Reach',
+  board: [
+    [0, 1, 1, 1],
+    [0, 1, 1, 1],
+    [0, 1, 0, 1],
+    [0, 1, 1, 1],
+    [1, 1, 1, 0],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4],
+};
+
+export default narrowReach;

--- a/src/data/levels/world-3/07-cross-draft.js
+++ b/src/data/levels/world-3/07-cross-draft.js
@@ -1,0 +1,15 @@
+import { PIECE_IDS } from '../../pieces';
+
+const crossDraft = {
+  id: 'world-3-cross-draft',
+  name: 'Cross Draft',
+  board: [
+    [1, 1, 1, 1, 1],
+    [1, 1, 0, 1, 1],
+    [0, 1, 0, 1, 0],
+    [0, 0, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4],
+};
+
+export default crossDraft;

--- a/src/data/levels/world-3/08-far-pocket.js
+++ b/src/data/levels/world-3/08-far-pocket.js
@@ -1,0 +1,15 @@
+import { PIECE_IDS } from '../../pieces';
+
+const farPocket = {
+  id: 'world-3-far-pocket',
+  name: 'Far Pocket',
+  board: [
+    [1, 1, 1, 1, 1],
+    [1, 1, 0, 1, 1],
+    [1, 1, 1, 1, 0],
+    [0, 0, 0, 1, 0],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4],
+};
+
+export default farPocket;

--- a/src/data/levels/world-3/index.js
+++ b/src/data/levels/world-3/index.js
@@ -1,0 +1,29 @@
+import { LEVEL_ACCESS } from '../access';
+import bendAhead from './04-bend-ahead';
+import crossDraft from './07-cross-draft';
+import farPocket from './08-far-pocket';
+import longLadder from './05-long-ladder';
+import longPorch from './01-long-porch';
+import narrowReach from './06-narrow-reach';
+import openStep from './03-open-step';
+import tallStack from './02-tall-stack';
+
+const world3Levels = [
+  longPorch,
+  tallStack,
+  openStep,
+  bendAhead,
+  longLadder,
+  narrowReach,
+  crossDraft,
+  farPocket,
+];
+
+export const WORLD_3_SET = {
+  id: 'world-3',
+  name: 'World 3',
+  access: LEVEL_ACCESS.PREMIUM,
+  levels: world3Levels,
+};
+
+export default WORLD_3_SET;

--- a/src/data/levels/world-4/01-straightaway.js
+++ b/src/data/levels/world-4/01-straightaway.js
@@ -1,0 +1,15 @@
+import { PIECE_IDS } from '../../pieces';
+
+const straightaway = {
+  id: 'world-4-straightaway',
+  name: 'Straightaway',
+  board: [
+    [0, 1, 1, 1, 1, 0],
+    [1, 0, 0, 1, 1, 1],
+    [1, 1, 1, 0, 1, 1],
+    [1, 0, 1, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default straightaway;

--- a/src/data/levels/world-4/02-wide-porch.js
+++ b/src/data/levels/world-4/02-wide-porch.js
@@ -1,0 +1,15 @@
+import { PIECE_IDS } from '../../pieces';
+
+const widePorch = {
+  id: 'world-4-wide-porch',
+  name: 'Wide Porch',
+  board: [
+    [0, 1, 1, 1, 1, 1],
+    [1, 0, 1, 0, 1, 1],
+    [1, 1, 1, 1, 0, 0],
+    [1, 0, 1, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default widePorch;

--- a/src/data/levels/world-4/03-long-channel.js
+++ b/src/data/levels/world-4/03-long-channel.js
@@ -1,0 +1,17 @@
+import { PIECE_IDS } from '../../pieces';
+
+const longChannel = {
+  id: 'world-4-long-channel',
+  name: 'Long Channel',
+  board: [
+    [1, 1, 1, 1],
+    [0, 1, 0, 1],
+    [0, 0, 0, 1],
+    [1, 1, 1, 1],
+    [1, 0, 1, 1],
+    [1, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default longChannel;

--- a/src/data/levels/world-4/04-reach-across.js
+++ b/src/data/levels/world-4/04-reach-across.js
@@ -1,0 +1,16 @@
+import { PIECE_IDS } from '../../pieces';
+
+const reachAcross = {
+  id: 'world-4-reach-across',
+  name: 'Reach Across',
+  board: [
+    [1, 1, 1, 1, 1],
+    [1, 1, 0, 1, 1],
+    [1, 1, 1, 1, 0],
+    [0, 0, 1, 0, 0],
+    [0, 1, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default reachAcross;

--- a/src/data/levels/world-4/05-split-rail.js
+++ b/src/data/levels/world-4/05-split-rail.js
@@ -1,0 +1,15 @@
+import { PIECE_IDS } from '../../pieces';
+
+const splitRail = {
+  id: 'world-4-split-rail',
+  name: 'Split Rail',
+  board: [
+    [0, 1, 1, 1, 1, 1],
+    [0, 1, 1, 0, 1, 0],
+    [1, 1, 1, 1, 1, 0],
+    [1, 0, 1, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default splitRail;

--- a/src/data/levels/world-4/06-span-lock.js
+++ b/src/data/levels/world-4/06-span-lock.js
@@ -1,0 +1,17 @@
+import { PIECE_IDS } from '../../pieces';
+
+const spanLock = {
+  id: 'world-4-span-lock',
+  name: 'Span Lock',
+  board: [
+    [1, 1, 1, 1],
+    [1, 1, 0, 1],
+    [1, 1, 0, 0],
+    [1, 1, 0, 0],
+    [1, 1, 1, 0],
+    [1, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default spanLock;

--- a/src/data/levels/world-4/07-wide-bend.js
+++ b/src/data/levels/world-4/07-wide-bend.js
@@ -1,0 +1,16 @@
+import { PIECE_IDS } from '../../pieces';
+
+const wideBend = {
+  id: 'world-4-wide-bend',
+  name: 'Wide Bend',
+  board: [
+    [0, 0, 0, 1, 1],
+    [1, 0, 0, 0, 1],
+    [1, 1, 1, 1, 1],
+    [1, 0, 1, 1, 1],
+    [1, 1, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default wideBend;

--- a/src/data/levels/world-4/08-final-run.js
+++ b/src/data/levels/world-4/08-final-run.js
@@ -1,0 +1,16 @@
+import { PIECE_IDS } from '../../pieces';
+
+const finalRun = {
+  id: 'world-4-final-run',
+  name: 'Final Run',
+  board: [
+    [1, 1, 1, 1, 1],
+    [1, 0, 0, 1, 1],
+    [1, 1, 1, 1, 0],
+    [1, 1, 1, 1, 0],
+    [1, 1, 0, 0, 0],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default finalRun;

--- a/src/data/levels/world-4/index.js
+++ b/src/data/levels/world-4/index.js
@@ -1,0 +1,29 @@
+import { LEVEL_ACCESS } from '../access';
+import finalRun from './08-final-run';
+import longChannel from './03-long-channel';
+import reachAcross from './04-reach-across';
+import spanLock from './06-span-lock';
+import splitRail from './05-split-rail';
+import straightaway from './01-straightaway';
+import wideBend from './07-wide-bend';
+import widePorch from './02-wide-porch';
+
+const world4Levels = [
+  straightaway,
+  widePorch,
+  longChannel,
+  reachAcross,
+  splitRail,
+  spanLock,
+  wideBend,
+  finalRun,
+];
+
+export const WORLD_4_SET = {
+  id: 'world-4',
+  name: 'World 4',
+  access: LEVEL_ACCESS.PREMIUM,
+  levels: world4Levels,
+};
+
+export default WORLD_4_SET;

--- a/src/data/levels/world-5/01-edge-nudge.js
+++ b/src/data/levels/world-5/01-edge-nudge.js
@@ -1,0 +1,16 @@
+import { PIECE_IDS } from '../../pieces';
+
+const edgeNudge = {
+  id: 'world-5-edge-nudge',
+  name: 'Edge Nudge',
+  board: [
+    [1, 0, 1, 0, 1],
+    [1, 1, 1, 1, 1],
+    [1, 0, 0, 0, 1],
+    [1, 1, 1, 1, 1],
+    [0, 1, 0, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default edgeNudge;

--- a/src/data/levels/world-5/02-notch-walk.js
+++ b/src/data/levels/world-5/02-notch-walk.js
@@ -1,0 +1,16 @@
+import { PIECE_IDS } from '../../pieces';
+
+const notchWalk = {
+  id: 'world-5-notch-walk',
+  name: 'Notch Walk',
+  board: [
+    [1, 1, 1, 0, 0],
+    [1, 1, 0, 0, 1],
+    [1, 1, 1, 1, 1],
+    [0, 0, 1, 1, 1],
+    [1, 1, 1, 0, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default notchWalk;

--- a/src/data/levels/world-5/03-crook-neck.js
+++ b/src/data/levels/world-5/03-crook-neck.js
@@ -1,0 +1,16 @@
+import { PIECE_IDS } from '../../pieces';
+
+const crookNeck = {
+  id: 'world-5-crook-neck',
+  name: 'Crook Neck',
+  board: [
+    [1, 1, 1, 1, 1],
+    [0, 0, 0, 1, 1],
+    [1, 0, 0, 0, 1],
+    [1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 0],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default crookNeck;

--- a/src/data/levels/world-5/04-frayed-edge.js
+++ b/src/data/levels/world-5/04-frayed-edge.js
@@ -1,0 +1,16 @@
+import { PIECE_IDS } from '../../pieces';
+
+const frayedEdge = {
+  id: 'world-5-frayed-edge',
+  name: 'Frayed Edge',
+  board: [
+    [1, 1, 1, 1, 0],
+    [1, 0, 0, 1, 1],
+    [1, 1, 1, 1, 1],
+    [1, 0, 1, 0, 1],
+    [0, 0, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default frayedEdge;

--- a/src/data/levels/world-5/05-side-cut.js
+++ b/src/data/levels/world-5/05-side-cut.js
@@ -1,0 +1,16 @@
+import { PIECE_IDS } from '../../pieces';
+
+const sideCut = {
+  id: 'world-5-side-cut',
+  name: 'Side Cut',
+  board: [
+    [1, 1, 1, 1, 1],
+    [1, 0, 0, 1, 1],
+    [1, 1, 0, 1, 1],
+    [1, 0, 0, 0, 1],
+    [1, 1, 1, 1, 0],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default sideCut;

--- a/src/data/levels/world-5/06-crooked-fence.js
+++ b/src/data/levels/world-5/06-crooked-fence.js
@@ -1,0 +1,16 @@
+import { PIECE_IDS } from '../../pieces';
+
+const crookedFence = {
+  id: 'world-5-crooked-fence',
+  name: 'Crooked Fence',
+  board: [
+    [1, 1, 1, 0, 0],
+    [1, 1, 1, 0, 1],
+    [1, 0, 1, 1, 1],
+    [0, 1, 1, 0, 1],
+    [1, 1, 1, 0, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default crookedFence;

--- a/src/data/levels/world-5/07-pocket-loop.js
+++ b/src/data/levels/world-5/07-pocket-loop.js
@@ -1,0 +1,17 @@
+import { PIECE_IDS } from '../../pieces';
+
+const pocketLoop = {
+  id: 'world-5-pocket-loop',
+  name: 'Pocket Loop',
+  board: [
+    [0, 0, 0, 1, 0],
+    [0, 0, 1, 1, 0],
+    [1, 0, 0, 1, 0],
+    [1, 0, 1, 1, 1],
+    [1, 1, 1, 0, 1],
+    [1, 1, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default pocketLoop;

--- a/src/data/levels/world-5/08-late-corner.js
+++ b/src/data/levels/world-5/08-late-corner.js
@@ -1,0 +1,17 @@
+import { PIECE_IDS } from '../../pieces';
+
+const lateCorner = {
+  id: 'world-5-late-corner',
+  name: 'Late Corner',
+  board: [
+    [0, 1, 1, 1, 1],
+    [1, 1, 0, 0, 0],
+    [1, 1, 1, 1, 1],
+    [0, 0, 1, 0, 1],
+    [0, 0, 1, 1, 0],
+    [0, 0, 1, 1, 1],
+  ],
+  pieceIds: [PIECE_IDS.SQUARE2, PIECE_IDS.LINE3, PIECE_IDS.L3, PIECE_IDS.T4, PIECE_IDS.LINE4],
+};
+
+export default lateCorner;

--- a/src/data/levels/world-5/index.js
+++ b/src/data/levels/world-5/index.js
@@ -1,0 +1,29 @@
+import { LEVEL_ACCESS } from '../access';
+import crookedFence from './06-crooked-fence';
+import edgeNudge from './01-edge-nudge';
+import frayedEdge from './04-frayed-edge';
+import lateCorner from './08-late-corner';
+import notchWalk from './02-notch-walk';
+import pocketLoop from './07-pocket-loop';
+import sideCut from './05-side-cut';
+import crookNeck from './03-crook-neck';
+
+const world5Levels = [
+  edgeNudge,
+  notchWalk,
+  crookNeck,
+  frayedEdge,
+  sideCut,
+  crookedFence,
+  pocketLoop,
+  lateCorner,
+];
+
+export const WORLD_5_SET = {
+  id: 'world-5',
+  name: 'World 5',
+  access: LEVEL_ACCESS.PREMIUM,
+  levels: world5Levels,
+};
+
+export default WORLD_5_SET;

--- a/src/data/levels/world-6/01-offset-entry.js
+++ b/src/data/levels/world-6/01-offset-entry.js
@@ -1,0 +1,23 @@
+import { PIECE_IDS } from '../../pieces';
+
+const offsetEntry = {
+  id: 'world-6-offset-entry',
+  name: 'Offset Entry',
+  board: [
+    [1, 1, 1, 1, 0, 0],
+    [1, 1, 0, 1, 1, 1],
+    [0, 1, 0, 1, 1, 1],
+    [0, 1, 1, 1, 0, 1],
+    [0, 1, 1, 1, 1, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default offsetEntry;

--- a/src/data/levels/world-6/02-shifted-block.js
+++ b/src/data/levels/world-6/02-shifted-block.js
@@ -1,0 +1,24 @@
+import { PIECE_IDS } from '../../pieces';
+
+const shiftedBlock = {
+  id: 'world-6-shifted-block',
+  name: 'Shifted Block',
+  board: [
+    [1, 1, 1, 1, 0],
+    [1, 1, 1, 1, 0],
+    [1, 1, 0, 1, 1],
+    [1, 1, 0, 0, 1],
+    [1, 1, 1, 1, 1],
+    [1, 0, 0, 1, 0],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default shiftedBlock;

--- a/src/data/levels/world-6/03-misalign.js
+++ b/src/data/levels/world-6/03-misalign.js
@@ -1,0 +1,23 @@
+import { PIECE_IDS } from '../../pieces';
+
+const misalign = {
+  id: 'world-6-misalign',
+  name: 'Misalign',
+  board: [
+    [1, 1, 1, 0, 1, 0],
+    [1, 1, 1, 1, 1, 0],
+    [1, 0, 1, 1, 1, 1],
+    [1, 1, 1, 0, 1, 1],
+    [0, 0, 1, 1, 0, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default misalign;

--- a/src/data/levels/world-6/04-offset-stack.js
+++ b/src/data/levels/world-6/04-offset-stack.js
@@ -1,0 +1,23 @@
+import { PIECE_IDS } from '../../pieces';
+
+const offsetStack = {
+  id: 'world-6-offset-stack',
+  name: 'Offset Stack',
+  board: [
+    [1, 1, 1, 1, 1, 0],
+    [1, 1, 0, 1, 1, 1],
+    [1, 1, 0, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1],
+    [1, 0, 0, 0, 0, 0],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default offsetStack;

--- a/src/data/levels/world-6/05-zig-pocket.js
+++ b/src/data/levels/world-6/05-zig-pocket.js
@@ -1,0 +1,23 @@
+import { PIECE_IDS } from '../../pieces';
+
+const zigPocket = {
+  id: 'world-6-zig-pocket',
+  name: 'Zig Pocket',
+  board: [
+    [0, 1, 1, 1, 1, 0],
+    [0, 1, 1, 1, 1, 1],
+    [1, 1, 0, 1, 1, 1],
+    [0, 1, 1, 1, 0, 1],
+    [0, 0, 1, 1, 1, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default zigPocket;

--- a/src/data/levels/world-6/06-side-slip.js
+++ b/src/data/levels/world-6/06-side-slip.js
@@ -1,0 +1,23 @@
+import { PIECE_IDS } from '../../pieces';
+
+const sideSlip = {
+  id: 'world-6-side-slip',
+  name: 'Side Slip',
+  board: [
+    [1, 1, 1, 1, 0, 0],
+    [1, 0, 1, 1, 1, 1],
+    [1, 0, 0, 1, 1, 1],
+    [1, 1, 0, 1, 1, 1],
+    [1, 1, 0, 1, 0, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default sideSlip;

--- a/src/data/levels/world-6/07-tight-shift.js
+++ b/src/data/levels/world-6/07-tight-shift.js
@@ -1,0 +1,23 @@
+import { PIECE_IDS } from '../../pieces';
+
+const tightShift = {
+  id: 'world-6-tight-shift',
+  name: 'Tight Shift',
+  board: [
+    [1, 1, 1, 1, 1, 1],
+    [0, 1, 1, 1, 1, 0],
+    [1, 1, 1, 0, 1, 1],
+    [0, 1, 1, 0, 1, 1],
+    [0, 0, 0, 1, 1, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default tightShift;

--- a/src/data/levels/world-6/08-elbow-crowd.js
+++ b/src/data/levels/world-6/08-elbow-crowd.js
@@ -1,0 +1,24 @@
+import { PIECE_IDS } from '../../pieces';
+
+const elbowCrowd = {
+  id: 'world-6-elbow-crowd',
+  name: 'Elbow Crowd',
+  board: [
+    [1, 0, 1, 1, 0],
+    [1, 1, 1, 1, 1],
+    [1, 0, 1, 1, 1],
+    [1, 1, 1, 1, 0],
+    [1, 1, 0, 0, 0],
+    [0, 1, 1, 1, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default elbowCrowd;

--- a/src/data/levels/world-6/index.js
+++ b/src/data/levels/world-6/index.js
@@ -1,0 +1,29 @@
+import { LEVEL_ACCESS } from '../access';
+import elbowCrowd from './08-elbow-crowd';
+import misalign from './03-misalign';
+import offsetEntry from './01-offset-entry';
+import offsetStack from './04-offset-stack';
+import shiftedBlock from './02-shifted-block';
+import sideSlip from './06-side-slip';
+import tightShift from './07-tight-shift';
+import zigPocket from './05-zig-pocket';
+
+const world6Levels = [
+  offsetEntry,
+  shiftedBlock,
+  misalign,
+  offsetStack,
+  zigPocket,
+  sideSlip,
+  tightShift,
+  elbowCrowd,
+];
+
+export const WORLD_6_SET = {
+  id: 'world-6',
+  name: 'World 6',
+  access: LEVEL_ACCESS.PREMIUM,
+  levels: world6Levels,
+};
+
+export default WORLD_6_SET;

--- a/src/data/levels/world-7/01-false-wall.js
+++ b/src/data/levels/world-7/01-false-wall.js
@@ -1,0 +1,25 @@
+import { PIECE_IDS } from '../../pieces';
+
+const falseWall = {
+  id: 'world-7-false-wall',
+  name: 'False Wall',
+  board: [
+    [1, 1, 0, 0, 0],
+    [0, 1, 1, 0, 0],
+    [0, 1, 1, 0, 0],
+    [1, 1, 1, 0, 1],
+    [1, 0, 1, 1, 1],
+    [1, 1, 1, 0, 1],
+    [0, 1, 1, 1, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default falseWall;

--- a/src/data/levels/world-7/02-double-bluff.js
+++ b/src/data/levels/world-7/02-double-bluff.js
@@ -1,0 +1,25 @@
+import { PIECE_IDS } from '../../pieces';
+
+const doubleBluff = {
+  id: 'world-7-double-bluff',
+  name: 'Double Bluff',
+  board: [
+    [1, 1, 1, 1, 1],
+    [1, 1, 0, 1, 1],
+    [1, 1, 1, 1, 0],
+    [1, 0, 0, 1, 1],
+    [1, 0, 0, 1, 0],
+    [1, 1, 0, 0, 0],
+    [0, 1, 1, 0, 0],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default doubleBluff;

--- a/src/data/levels/world-7/03-split-choice.js
+++ b/src/data/levels/world-7/03-split-choice.js
@@ -1,0 +1,23 @@
+import { PIECE_IDS } from '../../pieces';
+
+const splitChoice = {
+  id: 'world-7-split-choice',
+  name: 'Split Choice',
+  board: [
+    [1, 1, 1, 0, 1, 0, 1],
+    [1, 1, 0, 0, 1, 1, 1],
+    [1, 1, 0, 0, 1, 1, 0],
+    [0, 1, 0, 1, 1, 0, 0],
+    [1, 1, 1, 1, 1, 0, 0],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default splitChoice;

--- a/src/data/levels/world-7/04-narrow-fake.js
+++ b/src/data/levels/world-7/04-narrow-fake.js
@@ -1,0 +1,25 @@
+import { PIECE_IDS } from '../../pieces';
+
+const narrowFake = {
+  id: 'world-7-narrow-fake',
+  name: 'Narrow Fake',
+  board: [
+    [1, 1, 1, 1, 0],
+    [0, 1, 0, 0, 0],
+    [0, 1, 1, 1, 0],
+    [0, 1, 1, 1, 0],
+    [0, 1, 0, 1, 1],
+    [1, 1, 0, 1, 1],
+    [1, 0, 1, 1, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default narrowFake;

--- a/src/data/levels/world-7/05-left-decoy.js
+++ b/src/data/levels/world-7/05-left-decoy.js
@@ -1,0 +1,23 @@
+import { PIECE_IDS } from '../../pieces';
+
+const leftDecoy = {
+  id: 'world-7-left-decoy',
+  name: 'Left Decoy',
+  board: [
+    [0, 0, 1, 0, 0, 1, 0],
+    [1, 1, 1, 0, 1, 1, 1],
+    [1, 1, 1, 1, 1, 0, 1],
+    [0, 0, 0, 0, 1, 1, 1],
+    [0, 1, 1, 1, 1, 1, 0],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default leftDecoy;

--- a/src/data/levels/world-7/06-tight-relay.js
+++ b/src/data/levels/world-7/06-tight-relay.js
@@ -1,0 +1,25 @@
+import { PIECE_IDS } from '../../pieces';
+
+const tightRelay = {
+  id: 'world-7-tight-relay',
+  name: 'Tight Relay',
+  board: [
+    [0, 0, 0, 1, 1],
+    [0, 0, 0, 1, 1],
+    [1, 1, 1, 1, 1],
+    [1, 1, 1, 0, 1],
+    [1, 0, 1, 1, 1],
+    [1, 1, 1, 0, 0],
+    [1, 0, 1, 0, 0],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default tightRelay;

--- a/src/data/levels/world-7/07-center-trap.js
+++ b/src/data/levels/world-7/07-center-trap.js
@@ -1,0 +1,25 @@
+import { PIECE_IDS } from '../../pieces';
+
+const centerTrap = {
+  id: 'world-7-center-trap',
+  name: 'Center Trap',
+  board: [
+    [0, 1, 1, 0, 0],
+    [0, 1, 0, 0, 1],
+    [1, 1, 0, 1, 1],
+    [1, 1, 0, 1, 1],
+    [1, 0, 1, 0, 1],
+    [1, 1, 1, 1, 1],
+    [1, 0, 0, 0, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default centerTrap;

--- a/src/data/levels/world-7/08-final-feint.js
+++ b/src/data/levels/world-7/08-final-feint.js
@@ -1,0 +1,24 @@
+import { PIECE_IDS } from '../../pieces';
+
+const finalFeint = {
+  id: 'world-7-final-feint',
+  name: 'Final Feint',
+  board: [
+    [0, 1, 0, 0, 1, 0],
+    [1, 1, 0, 1, 1, 1],
+    [0, 1, 0, 1, 0, 1],
+    [0, 1, 1, 1, 0, 1],
+    [0, 1, 0, 1, 1, 1],
+    [1, 1, 0, 1, 1, 0],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+  ],
+};
+
+export default finalFeint;

--- a/src/data/levels/world-7/index.js
+++ b/src/data/levels/world-7/index.js
@@ -1,0 +1,29 @@
+import { LEVEL_ACCESS } from '../access';
+import centerTrap from './07-center-trap';
+import doubleBluff from './02-double-bluff';
+import falseWall from './01-false-wall';
+import finalFeint from './08-final-feint';
+import leftDecoy from './05-left-decoy';
+import narrowFake from './04-narrow-fake';
+import splitChoice from './03-split-choice';
+import tightRelay from './06-tight-relay';
+
+const world7Levels = [
+  falseWall,
+  doubleBluff,
+  splitChoice,
+  narrowFake,
+  leftDecoy,
+  tightRelay,
+  centerTrap,
+  finalFeint,
+];
+
+export const WORLD_7_SET = {
+  id: 'world-7',
+  name: 'World 7',
+  access: LEVEL_ACCESS.PREMIUM,
+  levels: world7Levels,
+};
+
+export default WORLD_7_SET;

--- a/src/data/levels/world-8/01-mirror-signal.js
+++ b/src/data/levels/world-8/01-mirror-signal.js
@@ -1,0 +1,24 @@
+import { PIECE_IDS } from '../../pieces';
+
+const mirrorSignal = {
+  id: 'world-8-mirror-signal',
+  name: 'Mirror Signal',
+  board: [
+    [0, 1, 1, 1, 1, 1, 1],
+    [1, 1, 0, 1, 1, 1, 0],
+    [1, 1, 1, 1, 1, 1, 1],
+    [0, 0, 1, 1, 0, 1, 1],
+    [0, 0, 0, 1, 1, 1, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+    PIECE_IDS.S4,
+  ],
+};
+
+export default mirrorSignal;

--- a/src/data/levels/world-8/02-packed-turn.js
+++ b/src/data/levels/world-8/02-packed-turn.js
@@ -1,0 +1,25 @@
+import { PIECE_IDS } from '../../pieces';
+
+const packedTurn = {
+  id: 'world-8-packed-turn',
+  name: 'Packed Turn',
+  board: [
+    [1, 1, 0, 1, 1, 0],
+    [1, 1, 1, 1, 0, 0],
+    [1, 1, 1, 1, 1, 1],
+    [0, 0, 1, 0, 1, 0],
+    [0, 1, 1, 1, 1, 0],
+    [1, 1, 1, 1, 1, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+    PIECE_IDS.S4,
+  ],
+};
+
+export default packedTurn;

--- a/src/data/levels/world-8/03-double-sweep.js
+++ b/src/data/levels/world-8/03-double-sweep.js
@@ -1,0 +1,24 @@
+import { PIECE_IDS } from '../../pieces';
+
+const doubleSweep = {
+  id: 'world-8-double-sweep',
+  name: 'Double Sweep',
+  board: [
+    [1, 0, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 0, 0, 1],
+    [1, 0, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1, 0],
+    [1, 1, 1, 0, 0, 0, 0],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+    PIECE_IDS.S4,
+  ],
+};
+
+export default doubleSweep;

--- a/src/data/levels/world-8/04-dense-crossing.js
+++ b/src/data/levels/world-8/04-dense-crossing.js
@@ -1,0 +1,24 @@
+import { PIECE_IDS } from '../../pieces';
+
+const denseCrossing = {
+  id: 'world-8-dense-crossing',
+  name: 'Dense Crossing',
+  board: [
+    [1, 1, 1, 1, 0, 1, 1],
+    [1, 1, 0, 1, 1, 1, 0],
+    [1, 1, 1, 1, 1, 0, 0],
+    [1, 1, 1, 1, 1, 1, 0],
+    [0, 1, 1, 0, 0, 1, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+    PIECE_IDS.S4,
+  ],
+};
+
+export default denseCrossing;

--- a/src/data/levels/world-8/05-triple-bend.js
+++ b/src/data/levels/world-8/05-triple-bend.js
@@ -1,0 +1,26 @@
+import { PIECE_IDS } from '../../pieces';
+
+const tripleBend = {
+  id: 'world-8-triple-bend',
+  name: 'Triple Bend',
+  board: [
+    [0, 0, 1, 1, 1],
+    [1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1],
+    [1, 0, 1, 1, 1],
+    [1, 1, 1, 0, 1],
+    [0, 1, 0, 1, 1],
+    [0, 0, 1, 1, 0],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+    PIECE_IDS.S4,
+  ],
+};
+
+export default tripleBend;

--- a/src/data/levels/world-8/06-folded-crowd.js
+++ b/src/data/levels/world-8/06-folded-crowd.js
@@ -1,0 +1,25 @@
+import { PIECE_IDS } from '../../pieces';
+
+const foldedCrowd = {
+  id: 'world-8-folded-crowd',
+  name: 'Folded Crowd',
+  board: [
+    [1, 0, 1, 0, 0, 1],
+    [1, 1, 1, 1, 1, 1],
+    [0, 1, 1, 1, 1, 1],
+    [0, 1, 1, 0, 1, 1],
+    [0, 0, 1, 1, 1, 1],
+    [0, 0, 1, 1, 1, 1],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+    PIECE_IDS.S4,
+  ],
+};
+
+export default foldedCrowd;

--- a/src/data/levels/world-8/07-near-full.js
+++ b/src/data/levels/world-8/07-near-full.js
@@ -1,0 +1,25 @@
+import { PIECE_IDS } from '../../pieces';
+
+const nearFull = {
+  id: 'world-8-near-full',
+  name: 'Near Full',
+  board: [
+    [0, 1, 0, 0, 0, 0],
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1],
+    [0, 0, 1, 1, 1, 1],
+    [0, 1, 1, 0, 1, 0],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+    PIECE_IDS.S4,
+  ],
+};
+
+export default nearFull;

--- a/src/data/levels/world-8/08-final-echo.js
+++ b/src/data/levels/world-8/08-final-echo.js
@@ -1,0 +1,25 @@
+import { PIECE_IDS } from '../../pieces';
+
+const finalEcho = {
+  id: 'world-8-final-echo',
+  name: 'Final Echo',
+  board: [
+    [0, 1, 1, 1, 1, 0],
+    [1, 1, 1, 1, 1, 1],
+    [1, 0, 1, 1, 1, 1],
+    [0, 1, 1, 1, 1, 1],
+    [0, 1, 1, 1, 1, 1],
+    [0, 0, 1, 0, 0, 0],
+  ],
+  pieceIds: [
+    PIECE_IDS.SQUARE2,
+    PIECE_IDS.LINE3,
+    PIECE_IDS.L3,
+    PIECE_IDS.T4,
+    PIECE_IDS.LINE4,
+    PIECE_IDS.Z4,
+    PIECE_IDS.S4,
+  ],
+};
+
+export default finalEcho;

--- a/src/data/levels/world-8/index.js
+++ b/src/data/levels/world-8/index.js
@@ -1,0 +1,29 @@
+import { LEVEL_ACCESS } from '../access';
+import denseCrossing from './04-dense-crossing';
+import doubleSweep from './03-double-sweep';
+import finalEcho from './08-final-echo';
+import foldedCrowd from './06-folded-crowd';
+import mirrorSignal from './01-mirror-signal';
+import nearFull from './07-near-full';
+import packedTurn from './02-packed-turn';
+import tripleBend from './05-triple-bend';
+
+const world8Levels = [
+  mirrorSignal,
+  packedTurn,
+  doubleSweep,
+  denseCrossing,
+  tripleBend,
+  foldedCrowd,
+  nearFull,
+  finalEcho,
+];
+
+export const WORLD_8_SET = {
+  id: 'world-8',
+  name: 'World 8',
+  access: LEVEL_ACCESS.PREMIUM,
+  levels: world8Levels,
+};
+
+export default WORLD_8_SET;


### PR DESCRIPTION
## Summary
Add the next campaign content wave by authoring Worlds 3-8 and registering them in the runtime level set list.

## What Changed
- added six new premium world folders under `src/data/levels/world-3` through `src/data/levels/world-8`
- appended Worlds 3-8 to `LEVEL_SETS` without changing the runtime schema
- generalized navigation and validation tests so the campaign no longer assumes World 2 is the final set
- added piece-set progression coverage for the world 3-8 expansion path

## Why
The repo had a documented world roadmap beyond World 2, but the shipped campaign stopped there and the tests still treated World 2 as the terminal world. This PR adds the next content wave while keeping paywall work out of scope.

## Impact
Players and playtesters can progress through Worlds 3-8 once premium access work is in place, and the content model can keep expanding without brittle end-of-campaign assumptions.

## Validation
- `npm run validate:levels`
- `npm test -- --run`
- `npm run build`

Closes #44
